### PR TITLE
Add more parameters to `/stats/history`

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -81,7 +81,7 @@ fn setup<'a>(
             stats::forward_destinations,
             stats::query_types,
             stats::history,
-            stats::history_timespan,
+            stats::history_params,
             stats::recent_blocked,
             stats::recent_blocked_params,
             stats::clients,

--- a/src/stats/history.rs
+++ b/src/stats/history.rs
@@ -17,13 +17,56 @@ use util;
 /// Get the entire query history (as stored in FTL)
 #[get("/stats/history")]
 pub fn history(ftl: State<FtlConnectionType>) -> util::Reply {
-    get_history(&ftl, "getallqueries")
+    get_history(&ftl, "getallqueries", None)
 }
 
-/// Get the query history within the specified timespan
-#[get("/stats/history?<timespan>")]
-pub fn history_timespan(ftl: State<FtlConnectionType>, timespan: Timespan) -> util::Reply {
-    get_history(&ftl, &format!("getallqueries-time {} {}", timespan.from, timespan.to))
+/// Get the query history according to the specified parameters
+#[get("/stats/history?<params>")]
+pub fn history_params(
+    ftl: State<FtlConnectionType>,
+    params: HistoryParams
+) -> util::Reply {
+    let limit = params.limit;
+    let command = match params {
+        // Get the query history within the specified timespan
+        HistoryParams {
+            from: Some(from),
+            until: Some(until),
+            domain: None,
+            client: None,
+            ..
+        } => {
+            format!("getallqueries-time {} {}", from, until)
+        },
+        // Get the query history for the specified domain
+        HistoryParams {
+            from: None,
+            until: None,
+            domain: Some(domain),
+            client: None,
+            ..
+        } => {
+            format!("getallqueries-domain {}", domain)
+        },
+        // Get the query history for the specified client
+        HistoryParams {
+            from: None,
+            until: None,
+            domain: None,
+            client: Some(client),
+            ..
+        } => {
+            format!("getallqueries-client {}", client)
+        },
+        // FTL can't handle mixed input
+        _ => return util::reply_error(util::Error::BadRequest)
+    };
+
+    get_history(
+        &ftl,
+        &command,
+        limit
+    )
 }
 
 /// Represents a query returned in `/stats/history`
@@ -32,14 +75,23 @@ struct Query(i32, String, String, String, u8, u8);
 
 /// Represents the possible GET parameters on `/stats/history`
 #[derive(FromForm)]
-pub struct Timespan {
-    from: u64,
-    to: u64
+pub struct HistoryParams {
+    from: Option<u64>,
+    until: Option<u64>,
+    domain: Option<String>,
+    client: Option<String>,
+    limit: Option<usize>
 }
 
 /// Get the query history according to the specified command
-fn get_history(ftl: &FtlConnectionType, command: &str) -> util::Reply {
-    let mut con = ftl.connect(command)?;
+fn get_history(ftl: &FtlConnectionType, command: &str, limit: Option<usize>) -> util::Reply {
+    let full_command = if let Some(num) = limit {
+        format!("{} ({})", command, num)
+    } else {
+        command.to_owned()
+    };
+
+    let mut con = ftl.connect(&full_command)?;
 
     // Create a 4KiB string buffer
     let mut str_buffer = [0u8; 4096];
@@ -118,6 +170,116 @@ mod test {
                             "doubleclick.com",
                             "client2",
                             1,
+                            1
+                        ]
+                    ],
+                    "errors": []
+                })
+            )
+            .test();
+    }
+
+    #[test]
+    fn test_history_timespan() {
+        let mut data = Vec::new();
+        encode::write_i32(&mut data, 1520126228).unwrap();
+        encode::write_str(&mut data, "IPv4").unwrap();
+        encode::write_str(&mut data, "example.com").unwrap();
+        encode::write_str(&mut data, "client1").unwrap();
+        encode::write_u8(&mut data, 2).unwrap();
+        encode::write_u8(&mut data, 1).unwrap();
+        encode::write_i32(&mut data, 1520126406).unwrap();
+        encode::write_str(&mut data, "IPv6").unwrap();
+        encode::write_str(&mut data, "doubleclick.com").unwrap();
+        encode::write_str(&mut data, "client2").unwrap();
+        encode::write_u8(&mut data, 1).unwrap();
+        encode::write_u8(&mut data, 1).unwrap();
+        write_eom(&mut data);
+
+        TestBuilder::new()
+            .endpoint("/admin/api/stats/history?from=1520126228&until=1520126406")
+            .ftl("getallqueries-time 1520126228 1520126406", data)
+            .expect_json(
+                json!({
+                    "data": [
+                        [
+                            1520126228,
+                            "IPv4",
+                            "example.com",
+                            "client1",
+                            2,
+                            1
+                        ],
+                        [
+                            1520126406,
+                            "IPv6",
+                            "doubleclick.com",
+                            "client2",
+                            1,
+                            1
+                        ]
+                    ],
+                    "errors": []
+                })
+            )
+            .test();
+    }
+
+    #[test]
+    fn test_history_domain() {
+        let mut data = Vec::new();
+        encode::write_i32(&mut data, 1520126228).unwrap();
+        encode::write_str(&mut data, "IPv4").unwrap();
+        encode::write_str(&mut data, "example.com").unwrap();
+        encode::write_str(&mut data, "client1").unwrap();
+        encode::write_u8(&mut data, 2).unwrap();
+        encode::write_u8(&mut data, 1).unwrap();
+        write_eom(&mut data);
+
+        TestBuilder::new()
+            .endpoint("/admin/api/stats/history?domain=example.com")
+            .ftl("getallqueries-domain example.com", data)
+            .expect_json(
+                json!({
+                    "data": [
+                        [
+                            1520126228,
+                            "IPv4",
+                            "example.com",
+                            "client1",
+                            2,
+                            1
+                        ]
+                    ],
+                    "errors": []
+                })
+            )
+            .test();
+    }
+
+    #[test]
+    fn test_history_client() {
+        let mut data = Vec::new();
+        encode::write_i32(&mut data, 1520126228).unwrap();
+        encode::write_str(&mut data, "IPv4").unwrap();
+        encode::write_str(&mut data, "example.com").unwrap();
+        encode::write_str(&mut data, "client1").unwrap();
+        encode::write_u8(&mut data, 2).unwrap();
+        encode::write_u8(&mut data, 1).unwrap();
+        write_eom(&mut data);
+
+        TestBuilder::new()
+            .endpoint("/admin/api/stats/history?client=client1")
+            .ftl("getallqueries-client client1", data)
+            .expect_json(
+                json!({
+                    "data": [
+                        [
+                            1520126228,
+                            "IPv4",
+                            "example.com",
+                            "client1",
+                            2,
                             1
                         ]
                     ],

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,7 +62,8 @@ pub enum Error {
     FtlConnectionFail,
     NotFound,
     AlreadyExists,
-    InvalidDomain
+    InvalidDomain,
+    BadRequest
 }
 
 impl Error {
@@ -77,7 +78,8 @@ impl Error {
             Error::FtlConnectionFail => "Failed to connect to FTL",
             Error::NotFound => "Not found",
             Error::AlreadyExists => "Item already exists",
-            Error::InvalidDomain => "Bad request"
+            Error::InvalidDomain => "Invalid domain",
+            Error::BadRequest => "Bad request"
         }
     }
 
@@ -91,7 +93,8 @@ impl Error {
             Error::FtlConnectionFail => "ftl_connection_fail",
             Error::NotFound => "not_found",
             Error::AlreadyExists => "already_exists",
-            Error::InvalidDomain => "invalid_domain"
+            Error::InvalidDomain => "invalid_domain",
+            Error::BadRequest => "bad_request"
         }
     }
 
@@ -104,7 +107,8 @@ impl Error {
             Error::FtlConnectionFail => Status::InternalServerError,
             Error::NotFound => Status::NotFound,
             Error::AlreadyExists => Status::Conflict,
-            Error::InvalidDomain => Status::BadRequest
+            Error::InvalidDomain => Status::BadRequest,
+            Error::BadRequest => Status::BadRequest
         }
     }
 }


### PR DESCRIPTION
This adds the rest of the FTL parameters to the API.

- The `to` parameter is renamed to `until`.
- FTL can only handle timespan, domain, or client history queries
independently, so a 400 Bad Request is returned if there is a mixture
of parameters specified.