### PR TITLE
Add Regex List Support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,7 @@ impl Config {
     }
 
     /// Check if a file exists
+    #[allow(unused)]
     pub fn file_exists(&self, file: PiholeFile) -> bool {
         match *self {
             Config::Production => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub enum PiholeFile {
     DnsmasqMainConfig,
     Whitelist,
     Blacklist,
-    Wildlist,
+    Regexlist,
     SetupVars
 }
 
@@ -30,7 +30,7 @@ impl PiholeFile {
             PiholeFile::DnsmasqMainConfig => "/etc/dnsmasq.d/01-pihole.conf",
             PiholeFile::Whitelist => "/etc/pihole/whitelist.txt",
             PiholeFile::Blacklist => "/etc/pihole/blacklist.txt",
-            PiholeFile::Wildlist => "/etc/dnsmasq.d/03-pihole-wildcard.conf",
+            PiholeFile::Regexlist => "/etc/pihole/regex.list",
             PiholeFile::SetupVars => "/etc/pihole/setupVars.conf"
         }
     }
@@ -63,6 +63,7 @@ impl Config {
         }
     }
 
+    /// Open a file for writing. If `append` is false, the file will be truncated.
     pub fn write_file(
         &self,
         file: PiholeFile,

--- a/src/dns/add_list.rs
+++ b/src/dns/add_list.rs
@@ -61,7 +61,7 @@ pub fn add_regexlist(config: State<Config>, ftl: State<FtlConnectionType>, domai
     add_list(PiholeFile::Regexlist, domain, &config)?;
 
     // At this point, since we haven't hit an error yet, tell FTL to recompile regex
-    ftl.connect(">recompile-regex")?.expect_eom()?;
+    ftl.connect("recompile-regex")?.expect_eom()?;
     util::reply_success()
 }
 
@@ -123,7 +123,7 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/dns/regexlist")
             .method(Method::Post)
-            .ftl(">recompile-regex", data)
+            .ftl("recompile-regex", data)
             .file_expect(
                 PiholeFile::Regexlist,
                 "",

--- a/src/dns/add_list.rs
+++ b/src/dns/add_list.rs
@@ -14,6 +14,7 @@ use dns::list::{add_list, try_remove_list};
 use rocket::State;
 use rocket_contrib::Json;
 use util;
+use ftl::FtlConnectionType;
 
 /// Represents an API input containing a domain
 #[derive(Deserialize)]
@@ -31,7 +32,7 @@ pub fn add_whitelist(config: State<Config>, domain_input: Json<DomainInput>) -> 
     try_remove_list(PiholeFile::Blacklist, domain, &config)?;
     try_remove_list(PiholeFile::Regexlist, domain, &config)?;
 
-    // At this point, since we haven't hit an error yet, reload gravity and return success
+    // At this point, since we haven't hit an error yet, reload gravity
     reload_gravity(PiholeFile::Whitelist, &config)?;
     util::reply_success()
 }
@@ -46,28 +47,28 @@ pub fn add_blacklist(config: State<Config>, domain_input: Json<DomainInput>) -> 
     try_remove_list(PiholeFile::Whitelist, domain, &config)?;
     try_remove_list(PiholeFile::Regexlist, domain, &config)?;
 
-    // At this point, since we haven't hit an error yet, reload gravity and return success
+    // At this point, since we haven't hit an error yet, reload gravity
     reload_gravity(PiholeFile::Blacklist, &config)?;
     util::reply_success()
 }
 
 /// Add a domain to the regex list
 #[post("/dns/regexlist", data = "<domain_input>")]
-pub fn add_regexlist(config: State<Config>, domain_input: Json<DomainInput>) -> util::Reply {
+pub fn add_regexlist(config: State<Config>, ftl: State<FtlConnectionType>, domain_input: Json<DomainInput>) -> util::Reply {
     let domain = &domain_input.0.domain;
 
-    // We only need to add it to the wildcard list (this is the same functionality as list.sh)
+    // We only need to add it to the regex list
     add_list(PiholeFile::Regexlist, domain, &config)?;
 
-    // At this point, since we haven't hit an error yet, reload gravity and return success
-    reload_gravity(PiholeFile::Regexlist, &config)?;
+    // At this point, since we haven't hit an error yet, tell FTL to recompile regex
+    ftl.connect(">recompile-regex")?.expect_eom()?;
     util::reply_success()
 }
 
 #[cfg(test)]
 mod test {
     use rocket::http::Method;
-    use testing::TestBuilder;
+    use testing::{TestBuilder, write_eom};
     use config::PiholeFile;
 
     #[test]
@@ -116,9 +117,13 @@ mod test {
 
     #[test]
     fn test_add_regexlist() {
+        let mut data = Vec::new();
+        write_eom(&mut data);
+
         TestBuilder::new()
             .endpoint("/admin/api/dns/regexlist")
             .method(Method::Post)
+            .ftl(">recompile-regex", data)
             .file_expect(
                 PiholeFile::Regexlist,
                 "",

--- a/src/dns/common.rs
+++ b/src/dns/common.rs
@@ -26,7 +26,13 @@ pub fn is_valid_domain(domain: &str) -> bool {
         && label_length_regex.is_match(domain)
 }
 
+/// Check if a regex is valid
+pub fn is_valid_regex(regex_str: &str) -> bool {
+    Regex::new(regex_str).is_ok()
+}
+
 /// Read in a value from setupVars.conf
+#[allow(unused)]
 pub fn read_setup_vars(entry: &str, config: &Config) -> io::Result<Option<String>> {
     // Open setupVars.conf
     let reader = BufReader::new(config.read_file(PiholeFile::SetupVars)?);
@@ -70,7 +76,7 @@ pub fn reload_gravity(list: PiholeFile, config: &Config) -> Result<(), util::Err
         .arg(match list {
             PiholeFile::Whitelist => "--whitelist-only",
             PiholeFile::Blacklist => "--blacklist-only",
-            PiholeFile::Wildlist => "--wildcard-only",
+            PiholeFile::Regexlist => "--wildcard-only",
             _ => return Err(util::Error::Unknown)
         })
         // Ignore stdin, stdout, and stderr

--- a/src/dns/common.rs
+++ b/src/dns/common.rs
@@ -76,7 +76,6 @@ pub fn reload_gravity(list: PiholeFile, config: &Config) -> Result<(), util::Err
         .arg(match list {
             PiholeFile::Whitelist => "--whitelist-only",
             PiholeFile::Blacklist => "--blacklist-only",
-            PiholeFile::Regexlist => "--wildcard-only",
             _ => return Err(util::Error::Unknown)
         })
         // Ignore stdin, stdout, and stderr

--- a/src/dns/delete_list.rs
+++ b/src/dns/delete_list.rs
@@ -34,11 +34,11 @@ pub fn delete_blacklist(config: State<Config>, domain: String) -> util::Reply {
     util::reply_success()
 }
 
-/// Delete a domain from the wildcard list
-#[delete("/dns/wildlist/<domain>")]
-pub fn delete_wildlist(config: State<Config>, domain: String) -> util::Reply {
-    remove_list(PiholeFile::Wildlist, &domain, &config)?;
-    reload_gravity(PiholeFile::Wildlist, &config)?;
+/// Delete a domain from the regex list
+#[delete("/dns/regexlist/<domain>")]
+pub fn delete_regexlist(config: State<Config>, domain: String) -> util::Reply {
+    remove_list(PiholeFile::Regexlist, &domain, &config)?;
+    reload_gravity(PiholeFile::Regexlist, &config)?;
 
     // At this point, since we haven't hit an error yet, reload gravity and return success
     util::reply_success()
@@ -81,11 +81,11 @@ mod test {
     }
 
     #[test]
-    fn test_delete_wildlist() {
+    fn test_delete_regexlist() {
         TestBuilder::new()
-            .endpoint("/admin/api/dns/wildlist/example.com")
+            .endpoint("/admin/api/dns/regexlist/^.*example.com$")
             .method(Method::Delete)
-            .file_expect(PiholeFile::Wildlist, "address=/example.com/10.1.1.1\n", "")
+            .file_expect(PiholeFile::Regexlist, "^.*example.com$\n", "")
             .file(PiholeFile::SetupVars, "IPV4_ADDRESS=10.1.1.1")
             .expect_json(
                 json!({

--- a/src/dns/delete_list.rs
+++ b/src/dns/delete_list.rs
@@ -35,7 +35,7 @@ pub fn delete_blacklist(config: State<Config>, domain: String) -> util::Reply {
 #[delete("/dns/regexlist/<domain>")]
 pub fn delete_regexlist(config: State<Config>, ftl: State<FtlConnectionType>, domain: String) -> util::Reply {
     remove_list(PiholeFile::Regexlist, &domain, &config)?;
-    ftl.connect(">recompile-regex")?.expect_eom()?;
+    ftl.connect("recompile-regex")?.expect_eom()?;
     util::reply_success()
 }
 
@@ -83,7 +83,7 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/dns/regexlist/^.*example.com$")
             .method(Method::Delete)
-            .ftl(">recompile-regex", data)
+            .ftl("recompile-regex", data)
             .file_expect(PiholeFile::Regexlist, "^.*example.com$\n", "")
             .file(PiholeFile::SetupVars, "IPV4_ADDRESS=10.1.1.1")
             .expect_json(

--- a/src/dns/get_list.rs
+++ b/src/dns/get_list.rs
@@ -25,10 +25,10 @@ pub fn get_blacklist(config: State<Config>) -> util::Reply {
     util::reply_data(get_list(PiholeFile::Blacklist, &config)?)
 }
 
-/// Get the Wildcard list domains
-#[get("/dns/wildlist")]
-pub fn get_wildlist(config: State<Config>) -> util::Reply {
-    util::reply_data(get_list(PiholeFile::Wildlist, &config)?)
+/// Get the Regex list domains
+#[get("/dns/regexlist")]
+pub fn get_regexlist(config: State<Config>) -> util::Reply {
+    util::reply_data(get_list(PiholeFile::Regexlist, &config)?)
 }
 
 #[cfg(test)]
@@ -67,17 +67,14 @@ mod test {
     }
 
     #[test]
-    fn test_get_wildlist() {
+    fn test_get_regexlist() {
         TestBuilder::new()
-            .endpoint("/admin/api/dns/wildlist")
-            .file(
-                PiholeFile::Wildlist,
-                "address=/example.com/10.1.1.1\naddress=/example.net/10.1.1.1\n"
-            )
+            .endpoint("/admin/api/dns/regexlist")
+            .file(PiholeFile::Regexlist, "^.*example.com$\nexample.net\n")
             .file(PiholeFile::SetupVars, "IPV4_ADDRESS=10.1.1.1")
             .expect_json(
                 json!([
-                    "example.com",
+                    "^.*example.com$",
                     "example.net"
                 ])
             )

--- a/src/dns/list.rs
+++ b/src/dns/list.rs
@@ -76,7 +76,12 @@ pub fn add_list(list: PiholeFile, domain: &str, config: &Config) -> Result<(), u
             .lines()
             .filter_map(|line| line.ok())
             // Only get valid domains
-            .filter(|domain| is_valid_domain(domain))
+            .filter(|domain| {
+                match list {
+                    PiholeFile::Regexlist => is_valid_regex(domain),
+                    _ => is_valid_domain(domain)
+                }
+            })
         );
     }
 

--- a/src/dns/list.rs
+++ b/src/dns/list.rs
@@ -65,25 +65,8 @@ pub fn add_list(list: PiholeFile, domain: &str, config: &Config) -> Result<(), u
         return Err(util::Error::InvalidDomain);
     }
 
-    let mut domains = Vec::new();
-
-    // Read list domains (if the list exists, otherwise the list is empty)
-    if config.file_exists(list) {
-        let reader = BufReader::new(config.read_file(list)?);
-
-        // Add domains
-        domains.extend(reader
-            .lines()
-            .filter_map(|line| line.ok())
-            // Only get valid domains
-            .filter(|domain| {
-                match list {
-                    PiholeFile::Regexlist => is_valid_regex(domain),
-                    _ => is_valid_domain(domain)
-                }
-            })
-        );
-    }
+    // Read list domains
+    let domains = get_list(list, config)?;
 
     // Check if the domain is already in the list
     if domains.contains(&domain.to_owned()) {
@@ -132,7 +115,7 @@ pub fn remove_list(list: PiholeFile, domain: &str, config: &Config) -> Result<()
 
     let domains = get_list(list, config)?;
 
-    // Check if the domain is already in the list
+    // Check if the domain is not in the list
     if !domains.contains(&domain.to_owned()) {
         return Err(util::Error::NotFound);
     }

--- a/src/dns/list.rs
+++ b/src/dns/list.rs
@@ -12,13 +12,13 @@ use std::io::prelude::*;
 use std::io::{self, BufReader, BufWriter};
 
 use util;
-use dns::common::{is_valid_domain, read_setup_vars};
+use dns::common::{is_valid_domain, is_valid_regex};
 use config::{Config, PiholeFile};
 
 /// Check that the file is a domain list, and return `Error::Unknown` otherwise
 fn verify_list(file: PiholeFile) -> Result<(), util::Error> {
     match file {
-        PiholeFile::Whitelist | PiholeFile::Blacklist | PiholeFile::Wildlist => Ok(()),
+        PiholeFile::Whitelist | PiholeFile::Blacklist | PiholeFile::Regexlist => Ok(()),
         _ => Err(util::Error::Unknown)
     }
 }
@@ -39,53 +39,13 @@ pub fn get_list(list: PiholeFile, config: &Config) -> Result<Vec<String>, util::
             }
         }
     };
+
     let reader = BufReader::new(file);
-
-    // Used for the wildcard list to skip IPv6 lines
-    let mut skip_lines = false;
-    let is_wildcard = list == PiholeFile::Wildlist;
-
-    if is_wildcard {
-        // Check if both IPv4 and IPv6 are used.
-        // If so, skip every other line if we're getting wildcard domains.
-        let ipv4 = read_setup_vars("IPV4_ADDRESS", config)?;
-        let ipv6 = read_setup_vars("IPV6_ADDRESS", config)?;
-
-        skip_lines = ipv4.is_some() && ipv6.is_some();
-    }
-
-    let mut skip = true;
-    let mut lines = Vec::new();
-
-    // Read in the domains
-    for line in reader.lines().filter_map(|item| item.ok()) {
-        // Skip empty lines
-        if line.len() == 0 {
-            continue;
-        }
-
-        // The wildcard list sometimes skips every other, see above
-        if skip_lines {
-            skip = !skip;
-
-            if skip {
-                continue;
-            }
-        }
-
-        // Parse the line
-        let mut parsed_line = if is_wildcard {
-            // If we're reading wildcards, the domain is between two forward slashes
-            match line.split("/").nth(1) {
-                Some(s) => s.to_owned(),
-                None => continue
-            }
-        } else {
-            line
-        };
-
-        lines.push(parsed_line);
-    }
+    let lines: Vec<String> = reader
+        .lines()
+        .filter_map(|line| line.ok())
+        .filter(|line| line.len() != 0)
+        .collect();
 
     Ok(lines)
 }
@@ -96,7 +56,12 @@ pub fn add_list(list: PiholeFile, domain: &str, config: &Config) -> Result<(), u
     verify_list(list)?;
 
     // Check if it's a valid domain before doing anything
-    if !is_valid_domain(domain) {
+    let valid_domain = match list {
+        PiholeFile::Regexlist => is_valid_regex(domain),
+        _ => is_valid_domain(domain)
+    };
+
+    if !valid_domain {
         return Err(util::Error::InvalidDomain);
     }
 
@@ -123,18 +88,8 @@ pub fn add_list(list: PiholeFile, domain: &str, config: &Config) -> Result<(), u
     // Open the list file in append mode (and create it if it doesn't exist)
     let mut list_file = config.write_file(list, true)?;
 
-    // Add the domain to the list (account for wildlist format)
-    if list == PiholeFile::Wildlist {
-        if let Some(ipv4) = read_setup_vars("IPV4_ADDRESS", config)? {
-            writeln!(list_file, "address=/{}/{}", domain, ipv4)?;
-        }
-
-        if let Some(ipv6) = read_setup_vars("IPV6_ADDRESS", config)? {
-            writeln!(list_file, "address=/{}/{}", domain, ipv6)?;
-        }
-    } else {
-        writeln!(list_file, "{}", domain)?;
-    }
+    // Add the domain to the list
+    writeln!(list_file, "{}", domain)?;
 
     Ok(())
 }
@@ -161,7 +116,12 @@ pub fn remove_list(list: PiholeFile, domain: &str, config: &Config) -> Result<()
     verify_list(list)?;
 
     // Check if it's a valid domain before doing anything
-    if !is_valid_domain(domain) {
+    let valid_domain = match list {
+        PiholeFile::Regexlist => is_valid_regex(domain),
+        _ => is_valid_domain(domain)
+    };
+
+    if !valid_domain {
         return Err(util::Error::InvalidDomain);
     }
 
@@ -178,25 +138,8 @@ pub fn remove_list(list: PiholeFile, domain: &str, config: &Config) -> Result<()
     let mut writer = BufWriter::new(list_file);
 
     // Write all domains except the one we're deleting
-    let domain_iter = domains.into_iter().filter(|item| item != domain);
-    if list == PiholeFile::Wildlist {
-        // Get the address information in case we're removing from the wildlist
-        let ipv4 = read_setup_vars("IPV4_ADDRESS", config)?;
-        let ipv6 = read_setup_vars("IPV6_ADDRESS", config)?;
-
-        for domain in domain_iter {
-            if let Some(ref address) = ipv4 {
-                writeln!(writer, "address=/{}/{}", domain, address)?;
-            }
-
-            if let Some(ref address) = ipv6 {
-                writeln!(writer, "address=/{}/{}", domain, address)?;
-            }
-        }
-    } else {
-        for domain in domain_iter {
-            writeln!(writer, "{}", domain)?;
-        }
+    for domain in domains.into_iter().filter(|item| item != domain) {
+        writeln!(writer, "{}", domain)?;
     }
 
     Ok(())

--- a/src/dns/list.rs
+++ b/src/dns/list.rs
@@ -13,7 +13,6 @@ use std::io::{self, BufReader, BufWriter};
 
 use util;
 use dns::common::{is_valid_domain, is_valid_regex};
-use setup_vars::read_setup_vars;
 use config::{Config, PiholeFile};
 
 /// Check that the file is a domain list, and return `Error::Unknown` otherwise

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -92,14 +92,14 @@ fn setup<'a>(
             stats::over_time_clients,
             dns::get_whitelist,
             dns::get_blacklist,
-            dns::get_wildlist,
+            dns::get_regexlist,
             dns::status,
             dns::add_whitelist,
             dns::add_blacklist,
-            dns::add_wildlist,
+            dns::add_regexlist,
             dns::delete_whitelist,
             dns::delete_blacklist,
-            dns::delete_wildlist
+            dns::delete_regexlist
         ])
         // Add custom error handlers
         .catch(errors![not_found])


### PR DESCRIPTION
This replaces the Wildlist/wildcard list support with regex support. This actually simplified some of the code. The tests have been updated.

Regex list support (`regex.list`) was added to FTL in this PR: pi-hole/FTL#288
The `>recompile-regex` command is also required: pi-hole/FTL#295