### PR TITLE
Fix deadlock caused by concurrent FTL API accesses

### DIFF
--- a/src/stats/over_time_clients.rs
+++ b/src/stats/over_time_clients.rs
@@ -19,10 +19,12 @@ use stats::clients::get_clients;
 /// Get the client queries over time
 #[get("/stats/overTime/clients")]
 pub fn over_time_clients(_auth: User, ftl: State<FtlConnectionType>) -> util::Reply {
-    let mut con = ftl.connect("ClientsoverTime")?;
-
     let mut over_time = Vec::new();
     let clients = get_clients(&ftl)?;
+
+    // Don't open another FTL connection until the connection from `get_clients` is done!
+    // Otherwise FTL's global lock mechanism will cause a deadlock.
+    let mut con = ftl.connect("ClientsoverTime")?;
 
     loop {
         // Get the timestamp, unless we are at the end of the list


### PR DESCRIPTION
FTL turns on a global thread lock when an API call runs, which effectively makes all API calls run in sequence and blocks the resolver until the call is finished. Because of this, opening one connection then opening a second and reading from the second causes a deadlock because FTL is trying to write to the first one while the API is waiting for the second connection's data.