### PR TITLE
Version Endpoint

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+
+fn main() {
+    // Read Git data and expose it to the API at compile time
+    let tag_raw = Command::new("git")
+        .args(&["describe", "--tags", "--abbrev=0", "--exact-match"])
+        .output()
+        .expect("Failed to get git tag");
+    let tag = String::from_utf8(tag_raw.stdout).unwrap();
+
+    let branch_raw = Command::new("git")
+        .args(&["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .expect("Failed to get git branch");
+    let branch = String::from_utf8(branch_raw.stdout).unwrap();
+
+    let hash_raw = Command::new("git")
+        .args(&["rev-parse", "HEAD"])
+        .output()
+        .expect("Failed to get commit hash");
+    let hash = String::from_utf8(hash_raw.stdout).unwrap();
+
+    // This lets us use the `env!()` macro to read these variables at compile time
+    println!("cargo:rustc-env=GIT_TAG={}", tag);
+    println!("cargo:rustc-env=GIT_BRANCH={}", branch);
+    println!("cargo:rustc-env=GIT_HASH={}", hash.get(0..7).unwrap()); // Get a short hash
+}

--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 # Install Rust
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates \
+    apt-get install -y --no-install-recommends curl ca-certificates git \
         gcc libc-dev gcc-aarch64-linux-gnu libc-dev-arm64-cross && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-07 && \
     export PATH="/root/.cargo/bin:$PATH" && \

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 # Install Rust
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates \
+    apt-get install -y --no-install-recommends curl ca-certificates git \
         gcc libc-dev gcc-arm-linux-gnueabi libc-dev-armel-cross && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-07 && \
     export PATH="/root/.cargo/bin:$PATH" && \

--- a/docker/armhf/Dockerfile
+++ b/docker/armhf/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 # Install Rust
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates \
+    apt-get install -y --no-install-recommends curl ca-certificates git \
         gcc libc-dev gcc-arm-linux-gnueabihf libc6-dev-armhf-cross && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-07 && \
     export PATH="/root/.cargo/bin:$PATH" && \

--- a/docker/x86_32/Dockerfile
+++ b/docker/x86_32/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 # Install Rust
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates gcc gcc-multilib && \
+    apt-get install -y --no-install-recommends curl ca-certificates gcc gcc-multilib git && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-07 && \
     export PATH="/root/.cargo/bin:$PATH" && \
     rustup target add i686-unknown-linux-gnu

--- a/docker/x86_64-musl/Dockerfile
+++ b/docker/x86_64-musl/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 # Install Rust
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates libc-dev musl-tools && \
+    apt-get install -y --no-install-recommends curl ca-certificates libc-dev musl-tools git && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-07 && \
     export PATH="/root/.cargo/bin:$PATH" && \
     rustup target add x86_64-unknown-linux-musl

--- a/docker/x86_64/Dockerfile
+++ b/docker/x86_64/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 # Install Rust
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl ca-certificates gcc libc-dev && \
+    apt-get install -y --no-install-recommends curl ca-certificates gcc libc-dev git && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-03-07 && \
     export PATH="/root/.cargo/bin:$PATH"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,9 @@ pub enum PiholeFile {
     Whitelist,
     Blacklist,
     Regexlist,
-    SetupVars
+    SetupVars,
+    LocalVersions,
+    LocalBranches
 }
 
 impl PiholeFile {
@@ -31,7 +33,9 @@ impl PiholeFile {
             PiholeFile::Whitelist => "/etc/pihole/whitelist.txt",
             PiholeFile::Blacklist => "/etc/pihole/blacklist.txt",
             PiholeFile::Regexlist => "/etc/pihole/regex.list",
-            PiholeFile::SetupVars => "/etc/pihole/setupVars.conf"
+            PiholeFile::SetupVars => "/etc/pihole/setupVars.conf",
+            PiholeFile::LocalVersions => "/etc/pihole/localversions",
+            PiholeFile::LocalBranches => "/etc/pihole/localbranches"
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod web;
 mod setup;
 mod config;
 mod setup_vars;
+mod version;
 
 #[cfg(test)]
 mod testing;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use util;
 use web;
+use version;
 
 /// This is run when no route could be found and returns a custom 404 message.
 #[error(404)]
@@ -95,6 +96,7 @@ fn setup<'a>(
         ])
         // Mount the API
         .mount("/admin/api", routes![
+            version::version,
             auth::check,
             auth::logout,
             stats::get_summary,

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,163 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2018 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  API
+*  Version endpoint
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+use rocket::State;
+use config::Config;
+use config::PiholeFile;
+use ftl::FtlConnectionType;
+use util;
+use std::io::Read;
+
+/// Get the versions of all Pi-hole systems
+#[get("/version")]
+pub fn version(config: State<Config>, ftl: State<FtlConnectionType>) -> util::Reply {
+    // Core
+    // Web
+    // FTL
+    // API
+    let core_version = read_core_version(&config)?;
+
+    util::reply_data(json!({
+        "core": core_version,
+    }))
+}
+
+/// Read Core version information from the file system
+fn read_core_version(config: &Config) -> Result<Version, util::Error> {
+    // Read the version files
+    let mut local_versions = String::new();
+    let mut local_branches = String::new();
+    config.read_file(PiholeFile::LocalVersions)?
+        .read_to_string(&mut local_versions)?;
+    config.read_file(PiholeFile::LocalBranches)?
+        .read_to_string(&mut local_branches)?;
+
+    // These files are structured as "CORE WEB FTL", but we only want Core's data
+    let git_version = local_versions.split_whitespace().next().unwrap_or_default();
+    let core_branch = local_branches.split_whitespace().next().unwrap_or_default();
+
+    // Parse the version data
+    Ok(parse_version(git_version, core_branch)?)
+}
+
+/// Parse version data from the output of `git describe` (stored in `PiholeFile::LocalVersions`).
+/// The string is in the form `TAG-NUMBER-COMMIT`.
+fn parse_version(git_version: &str, branch: &str) -> Result<Version, util::Error> {
+    let split: Vec<&str> = git_version.split("-").collect();
+
+    if split.len() != 3 {
+        return Err(util::Error::Unknown);
+    }
+
+    // Only set the tag if this is the tagged commit (we are 0 commits after the tag)
+    let tag = if split[1] == "0" { split[0] } else { "" };
+
+    Ok(Version {
+        tag: tag.to_owned(),
+        branch: branch.to_owned(),
+        // Ignore the beginning "g" character
+        hash: split[2].get(1..).unwrap_or_default().to_owned()
+    })
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+struct Version {
+    tag: String,
+    branch: String,
+    hash: String
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_version, Version};
+    use util;
+    use testing::TestConfigBuilder;
+    use config::PiholeFile;
+    use config::Config;
+    use version::read_core_version;
+
+    #[test]
+    fn test_read_core_version_valid() {
+        let test_config = Config::Test(
+            TestConfigBuilder::new()
+                .file(
+                    PiholeFile::LocalVersions,
+                    "v3.3.1-219-g6689e00 v3.3-190-gf7e1a28 vDev-d06deca"
+                )
+                .file(
+                    PiholeFile::LocalBranches,
+                    "development devel tweak/getClientNames"
+                )
+                .build()
+        );
+
+        assert_eq!(
+            read_core_version(&test_config),
+            Ok(Version {
+                tag: "".to_owned(),
+                branch: "development".to_owned(),
+                hash: "6689e00".to_owned()
+            })
+        )
+    }
+
+    #[test]
+    fn test_read_core_version_invalid() {
+        let test_config = Config::Test(
+            TestConfigBuilder::new()
+                .file(
+                    PiholeFile::LocalVersions,
+                    "invalid v3.3-190-gf7e1a28 vDev-d06deca"
+                )
+                .file(
+                    PiholeFile::LocalBranches,
+                    "development devel tweak/getClientNames"
+                )
+                .build()
+        );
+
+        assert_eq!(
+            read_core_version(&test_config),
+            Err(util::Error::Unknown)
+        )
+    }
+
+    #[test]
+    fn test_parse_version_valid() {
+        assert_eq!(
+            parse_version("v3.3.1-0-gfbee18e", "master"),
+            Ok(Version {
+                tag: "v3.3.1".to_owned(),
+                branch: "master".to_owned(),
+                hash: "fbee18e".to_owned()
+            })
+        )
+    }
+
+    #[test]
+    fn test_parse_version_old_tag() {
+        assert_eq!(
+            parse_version("v3.3.1-222-gd9c924b", "development"),
+            Ok(Version {
+                tag: "".to_owned(),
+                branch: "development".to_owned(),
+                hash: "d9c924b".to_owned()
+            })
+        )
+    }
+
+    #[test]
+    fn test_parse_version_invalid() {
+        assert_eq!(
+            parse_version("invalid data", "branch"),
+            Err(util::Error::Unknown)
+        )
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -20,10 +20,6 @@ use std::str;
 /// Get the versions of all Pi-hole systems
 #[get("/version")]
 pub fn version(config: State<Config>, ftl: State<FtlConnectionType>) -> util::Reply {
-    // Core
-    // Web
-    // FTL
-    // API
     let core_version = read_core_version(&config).unwrap_or_default();
     let web_version = read_web_version().unwrap_or_default();
     let ftl_version = read_ftl_version(&ftl).unwrap_or_default();

--- a/src/version.rs
+++ b/src/version.rs
@@ -14,6 +14,7 @@ use config::PiholeFile;
 use ftl::FtlConnectionType;
 use util;
 use std::io::Read;
+use web::WebAssets;
 
 /// Get the versions of all Pi-hole systems
 #[get("/version")]
@@ -22,44 +23,75 @@ pub fn version(config: State<Config>, ftl: State<FtlConnectionType>) -> util::Re
     // Web
     // FTL
     // API
-    let core_version = read_core_version(&config)?;
+    let core_version = read_core_version(&config).unwrap_or_default();
+    let web_version = read_web_version().unwrap_or_default();
 
     util::reply_data(json!({
         "core": core_version,
+        "web": web_version
     }))
 }
 
+/// Read Web version information from the `VERSION` file in the web assets.
+fn read_web_version() -> Option<Version> {
+   WebAssets::get("VERSION")
+        .and_then(|raw| String::from_utf8(raw).ok())
+        .and_then(|version| parse_web_version(&version))
+}
+
+/// Parse Web version information from the string.
+/// The string should be in the format "TAG BRANCH COMMIT".
+fn parse_web_version(version_str: &str) -> Option<Version> {
+    // Trim to remove possible newline
+    let version_split: Vec<&str> = version_str
+        .trim_right_matches("\n")
+        .split(" ")
+        .collect();
+
+    if version_split.len() != 3 {
+        return None;
+    }
+
+    Some(Version {
+        tag: version_split[0].to_owned(),
+        branch: version_split[1].to_owned(),
+        hash: version_split[2].to_owned()
+    })
+}
+
 /// Read Core version information from the file system
-fn read_core_version(config: &Config) -> Result<Version, util::Error> {
+fn read_core_version(config: &Config) -> Option<Version> {
     // Read the version files
     let mut local_versions = String::new();
     let mut local_branches = String::new();
-    config.read_file(PiholeFile::LocalVersions)?
-        .read_to_string(&mut local_versions)?;
-    config.read_file(PiholeFile::LocalBranches)?
-        .read_to_string(&mut local_branches)?;
+    config.read_file(PiholeFile::LocalVersions)
+        .ok()
+        .and_then(|mut f| f.read_to_string(&mut local_versions).ok());
+    config.read_file(PiholeFile::LocalBranches)
+        .ok()
+        .and_then(|mut f| f.read_to_string(&mut local_branches).ok());
 
     // These files are structured as "CORE WEB FTL", but we only want Core's data
-    let git_version = local_versions.split_whitespace().next().unwrap_or_default();
-    let core_branch = local_branches.split_whitespace().next().unwrap_or_default();
+    let git_version = local_versions.split(" ").next().unwrap_or_default();
+    let core_branch = local_branches.split(" ").next().unwrap_or_default();
 
     // Parse the version data
-    Ok(parse_version(git_version, core_branch)?)
+    parse_git_version(git_version, core_branch)
 }
 
 /// Parse version data from the output of `git describe` (stored in `PiholeFile::LocalVersions`).
-/// The string is in the form `TAG-NUMBER-COMMIT`.
-fn parse_version(git_version: &str, branch: &str) -> Result<Version, util::Error> {
+/// The string is in the form "TAG-NUMBER-COMMIT".
+fn parse_git_version(git_version: &str, branch: &str) -> Option<Version> {
     let split: Vec<&str> = git_version.split("-").collect();
 
     if split.len() != 3 {
-        return Err(util::Error::Unknown);
+        return None;
     }
 
     // Only set the tag if this is the tagged commit (we are 0 commits after the tag)
     let tag = if split[1] == "0" { split[0] } else { "" };
 
-    Ok(Version {
+    Some(Version {
         tag: tag.to_owned(),
         branch: branch.to_owned(),
         // Ignore the beginning "g" character
@@ -67,7 +99,7 @@ fn parse_version(git_version: &str, branch: &str) -> Result<Version, util::Error
     })
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq, Serialize, Default)]
 struct Version {
     tag: String,
     branch: String,
@@ -76,12 +108,52 @@ struct Version {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_version, Version};
-    use util;
+    use super::{Version, parse_git_version, parse_web_version};
     use testing::TestConfigBuilder;
     use config::PiholeFile;
     use config::Config;
     use version::read_core_version;
+
+    #[test]
+    fn test_parse_web_version_dev() {
+        assert_eq!(
+            parse_web_version(" development d2037fd"),
+            Some(Version {
+                tag: "".to_owned(),
+                branch: "development".to_owned(),
+                hash: "d2037fd".to_owned()
+            })
+        )
+    }
+
+    #[test]
+    fn test_parse_web_version_release() {
+        assert_eq!(
+            parse_web_version("v1.0.0 master abcdefg"),
+            Some(Version {
+                tag: "v1.0.0".to_owned(),
+                branch: "master".to_owned(),
+                hash: "abcdefg".to_owned()
+            })
+        )
+    }
+
+    #[test]
+    fn test_parse_web_version_invalid() {
+        assert_eq!(parse_web_version("invalid data"), None)
+    }
+
+    #[test]
+    fn test_parse_web_version_newline() {
+        assert_eq!(
+            parse_web_version(" development d2037fd\n"),
+            Some(Version {
+                tag: "".to_owned(),
+                branch: "development".to_owned(),
+                hash: "d2037fd".to_owned()
+            })
+        )
+    }
 
     #[test]
     fn test_read_core_version_valid() {
@@ -100,7 +172,7 @@ mod tests {
 
         assert_eq!(
             read_core_version(&test_config),
-            Ok(Version {
+            Some(Version {
                 tag: "".to_owned(),
                 branch: "development".to_owned(),
                 hash: "6689e00".to_owned()
@@ -123,17 +195,14 @@ mod tests {
                 .build()
         );
 
-        assert_eq!(
-            read_core_version(&test_config),
-            Err(util::Error::Unknown)
-        )
+        assert_eq!(read_core_version(&test_config), None)
     }
 
     #[test]
-    fn test_parse_version_valid() {
+    fn test_parse_git_version_release() {
         assert_eq!(
-            parse_version("v3.3.1-0-gfbee18e", "master"),
-            Ok(Version {
+            parse_git_version("v3.3.1-0-gfbee18e", "master"),
+            Some(Version {
                 tag: "v3.3.1".to_owned(),
                 branch: "master".to_owned(),
                 hash: "fbee18e".to_owned()
@@ -142,10 +211,10 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_version_old_tag() {
+    fn test_parse_git_version_dev() {
         assert_eq!(
-            parse_version("v3.3.1-222-gd9c924b", "development"),
-            Ok(Version {
+            parse_git_version("v3.3.1-222-gd9c924b", "development"),
+            Some(Version {
                 tag: "".to_owned(),
                 branch: "development".to_owned(),
                 hash: "d9c924b".to_owned()
@@ -154,10 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_version_invalid() {
-        assert_eq!(
-            parse_version("invalid data", "branch"),
-            Err(util::Error::Unknown)
-        )
+    fn test_parse_git_version_invalid() {
+        assert_eq!(parse_git_version("invalid data", "branch"), None)
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -80,11 +80,12 @@ fn read_core_version(config: &Config) -> Result<Version, util::Error> {
 }
 
 /// Parse version data from the output of `git describe` (stored in `PiholeFile::LocalVersions`).
-/// The string is in the form "TAG-NUMBER-COMMIT".
+/// The string is in the form "TAG-NUMBER-COMMIT", though it could also have "-dirty" at the end.
 fn parse_git_version(git_version: &str, branch: &str) -> Result<Version, util::Error> {
     let split: Vec<&str> = git_version.split("-").collect();
 
-    if split.len() != 3 {
+    // Could include "-dirty", which would make the length equal 4
+    if split.len() < 3 {
         return Err(util::Error::Unknown);
     }
 
@@ -228,6 +229,18 @@ mod tests {
         assert_eq!(
             parse_git_version("invalid data", "branch"),
             Err(util::Error::Unknown)
+        );
+    }
+
+    #[test]
+    fn test_parse_git_version_dirty() {
+        assert_eq!(
+            parse_git_version("v3.3.1-222-gd9c924b-dirty", "development"),
+            Ok(Version {
+                tag: "".to_owned(),
+                branch: "development".to_owned(),
+                hash: "d9c924b".to_owned()
+            })
         );
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -27,12 +27,23 @@ pub fn version(config: State<Config>, ftl: State<FtlConnectionType>) -> util::Re
     let core_version = read_core_version(&config).unwrap_or_default();
     let web_version = read_web_version().unwrap_or_default();
     let ftl_version = read_ftl_version(&ftl).unwrap_or_default();
+    let api_version = read_api_version();
 
     util::reply_data(json!({
         "core": core_version,
         "web": web_version,
-        "ftl": ftl_version
+        "ftl": ftl_version,
+        "api": api_version
     }))
+}
+
+/// Read API version information from the compile-time environment variables
+fn read_api_version() -> Version {
+    Version {
+        tag: env!("GIT_TAG").to_owned(),
+        branch: env!("GIT_BRANCH").to_owned(),
+        hash: env!("GIT_HASH").to_owned()
+    }
 }
 
 /// Read FTL version information from FTL's API

--- a/src/web.rs
+++ b/src/web.rs
@@ -15,7 +15,7 @@ use std::io::Cursor;
 
 #[derive(RustEmbed)]
 #[folder = "web/"]
-struct WebAssets;
+pub struct WebAssets;
 
 /// Get a file from the embedded web assets
 fn get_file<'r>(filename: &str) -> Option<Response<'r>> {


### PR DESCRIPTION
Endpoint URL: `/admin/api/version`

Closes #8 

Core version is gotten via `/etc/pihole/localversions` and `/etc/pihole/localbranches`.
Web version is gotten via the `VERSIONS` file inserted during the CI build (see pi-hole/web#42).
FTL version is gotten via the ">version" FTL API command (requires pi-hole/FTL#305)
API version is gotten via compile time environment variables generated by a build script (`build.rs`).

The functionality of making test configs was extracted from `TestBuilder` into `TestConfigBuilder` so test configs can be made and used without going through a whole fake network request test.

Example output:
```json
{
   "api":{
      "branch":"feature/version-endpoint",
      "hash":"d5798fa",
      "tag":"test"
   },
   "core":{
      "branch":"development",
      "hash":"6689e00",
      "tag":""
   },
   "ftl":{
      "branch":"tweak/version-api",
      "hash":"4d5da59",
      "tag":""
   },
   "web":{
      "branch":"feature/build-version",
      "hash":"648fbe8",
      "tag":""
   }
}
```