### PR TITLE
Make the build script work without being in a git repo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,23 +5,26 @@ fn main() {
     let tag_raw = Command::new("git")
         .args(&["describe", "--tags", "--abbrev=0", "--exact-match"])
         .output()
-        .expect("Failed to get git tag");
-    let tag = String::from_utf8(tag_raw.stdout).unwrap();
+        .map(|output| output.stdout)
+        .unwrap_or_default();
+    let tag = String::from_utf8(tag_raw).unwrap();
 
     let branch_raw = Command::new("git")
         .args(&["rev-parse", "--abbrev-ref", "HEAD"])
         .output()
-        .expect("Failed to get git branch");
-    let branch = String::from_utf8(branch_raw.stdout).unwrap();
+        .map(|output| output.stdout)
+        .unwrap_or_default();
+    let branch = String::from_utf8(branch_raw).unwrap();
 
     let hash_raw = Command::new("git")
         .args(&["rev-parse", "HEAD"])
         .output()
-        .expect("Failed to get commit hash");
-    let hash = String::from_utf8(hash_raw.stdout).unwrap();
+        .map(|output| output.stdout)
+        .unwrap_or_default();
+    let hash = String::from_utf8(hash_raw).unwrap();
 
     // This lets us use the `env!()` macro to read these variables at compile time
-    println!("cargo:rustc-env=GIT_TAG={}", tag);
-    println!("cargo:rustc-env=GIT_BRANCH={}", branch);
-    println!("cargo:rustc-env=GIT_HASH={}", hash.get(0..7).unwrap()); // Get a short hash
+    println!("cargo:rustc-env=GIT_TAG={}", tag.trim());
+    println!("cargo:rustc-env=GIT_BRANCH={}", branch.trim());
+    println!("cargo:rustc-env=GIT_HASH={}", hash.trim());
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -37,7 +37,7 @@ fn read_api_version() -> Version {
     Version {
         tag: env!("GIT_TAG").to_owned(),
         branch: env!("GIT_BRANCH").to_owned(),
-        hash: env!("GIT_HASH").to_owned()
+        hash: env!("GIT_HASH").get(0..7).unwrap_or_default().to_owned() // Use a short hash
     }
 }
 


### PR DESCRIPTION
This allows you to build it even if you just have a copy of the code and not the repository.