### PR TITLE
Use Failure For Errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +52,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "byteorder"
 version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cc"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -84,6 +110,25 @@ dependencies = [
 name = "dtoa"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "failure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "fuchsia-zircon"
@@ -286,6 +331,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pihole_api"
 version = "0.1.0"
 dependencies = [
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rmp 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -487,6 +534,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "safemem"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +628,15 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -783,15 +844,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
+"checksum backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbdd17cd962b570302f5297aea8648d5923e22e555c2ed2d8b2e34eca646bf6d"
+"checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "652805b7e73fada9d85e9a6682a4abd490cb52d96aeecc12e33a0de34dfd0d23"
+"checksum cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "49ec142f5768efb5b7622aebc3fdbdbb8950a4b9ba996393cb76ef7466e8747d"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
+"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
@@ -838,6 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rocket_contrib 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8c65e9bac3d41a9011adb4adccc819ab4a182657eb5cd478fd0e2a3c1eb7dfe"
 "checksum rocket_cors 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af8ef9a2b1153d0ec537cde8a98e306ef838804cc57074738f0675b6571b0f7e"
 "checksum rust-embed 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb4109a8a19a5fdbbd30d5433de1db7218b53f35748eb28c36d24647aaa2fd45"
+"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
@@ -850,6 +917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.12.14 (registry+https://github.com/rust-lang/crates.io-index)" = "8c5bc2d6ff27891209efa5f63e9de78648d7801f085e4653701a692ce938d6fd"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rmp = "0.8"
 regex = "0.2"
 rust-embed = "3.0.0"
 toml = "0.4"
+failure = "0.1.1"
+failure_derive = "0.1.1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -23,7 +23,7 @@ impl User {
     fn authenticate(request: &Request, input_key: &str) -> request::Outcome<Self, util::Error> {
         let auth_data: State<AuthData> = match request.guard().succeeded() {
             Some(auth_data) => auth_data,
-            None => return util::Error::Unknown.as_outcome()
+            None => return util::ErrorKind::Unknown.into().as_outcome()
         };
 
         if auth_data.key_matches(input_key) {
@@ -32,7 +32,7 @@ impl User {
 
             Outcome::Success(user)
         } else {
-            util::Error::Unauthorized.as_outcome()
+            util::ErrorKind::Unauthorized.into().as_outcome()
         }
     }
 
@@ -41,7 +41,7 @@ impl User {
             .get_private(USER_ATTR)
             .and_then(|cookie| cookie.value().parse().ok())
             .map(|id| User { id })
-            .into_outcome((util::Error::Unauthorized.status(), util::Error::Unauthorized))
+            .ok_or_else(|| util::ErrorKind::Unauthorized.into().as_outcome())
     }
 
     fn logout(&self, mut cookies: Cookies) {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -3,7 +3,7 @@ use rocket::Outcome;
 use rocket::outcome::IntoOutcome;
 use rocket::http::{Cookie, Cookies};
 use std::sync::atomic::{Ordering, AtomicUsize};
-use util;
+use util::{Reply, Error, ErrorKind, reply_success};
 
 const USER_ATTR: &str = "user_id";
 const AUTH_HEADER: &str = "X-Pi-hole-Authenticate";
@@ -20,10 +20,10 @@ pub struct AuthData {
 }
 
 impl User {
-    fn authenticate(request: &Request, input_key: &str) -> request::Outcome<Self, util::Error> {
+    fn authenticate(request: &Request, input_key: &str) -> request::Outcome<Self, Error> {
         let auth_data: State<AuthData> = match request.guard().succeeded() {
             Some(auth_data) => auth_data,
-            None => return util::ErrorKind::Unknown.into().as_outcome()
+            None => return Error::from(ErrorKind::Unknown).into_outcome()
         };
 
         if auth_data.key_matches(input_key) {
@@ -32,16 +32,16 @@ impl User {
 
             Outcome::Success(user)
         } else {
-            util::ErrorKind::Unauthorized.into().as_outcome()
+            Error::from(ErrorKind::Unauthorized).into_outcome()
         }
     }
 
-    fn check_cookies(mut cookies: Cookies) -> request::Outcome<Self, util::Error> {
+    fn check_cookies(mut cookies: Cookies) -> request::Outcome<Self, Error> {
         cookies
             .get_private(USER_ATTR)
             .and_then(|cookie| cookie.value().parse().ok())
             .map(|id| User { id })
-            .ok_or_else(|| util::ErrorKind::Unauthorized.into().as_outcome())
+            .into_outcome((ErrorKind::Unauthorized.status(), Error::from(ErrorKind::Unauthorized)))
     }
 
     fn logout(&self, mut cookies: Cookies) {
@@ -50,7 +50,7 @@ impl User {
 }
 
 impl<'a, 'r> FromRequest<'a, 'r> for User {
-    type Error = util::Error;
+    type Error = Error;
 
     fn from_request(request: &'a Request<'r>) -> request::Outcome<Self, Self::Error> {
         match request.headers().get_one(AUTH_HEADER) {
@@ -89,15 +89,15 @@ impl AuthData {
 
 /// Provides an endpoint to authenticate or check if already authenticated
 #[get("/auth")]
-pub fn check(_user: User) -> util::Reply {
-    util::reply_success()
+pub fn check(_user: User) -> Reply {
+    reply_success()
 }
 
 /// Clears the user's authentication
 #[delete("/auth")]
-pub fn logout(user: User, cookies: Cookies) -> util::Reply {
+pub fn logout(user: User, cookies: Cookies) -> Reply {
     user.logout(cookies);
-    util::reply_success()
+    reply_success()
 }
 
 #[cfg(test)]

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -11,11 +11,10 @@
 use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::os::unix::fs::OpenOptionsExt;
-use std::io;
 use std::path::Path;
 use config::Config;
 use config::PiholeFile;
-use util;
+use util::{Error, ErrorKind};
 use failure::ResultExt;
 
 /// Environment of the Pi-hole API. Stores the config and abstracts away some systems to make
@@ -41,18 +40,22 @@ impl Env {
     }
 
     /// Open a file for reading
-    pub fn read_file(&self, file: PiholeFile) -> Result<File, util::Error> {
+    pub fn read_file(&self, file: PiholeFile) -> Result<File, Error> {
         match *self {
             Env::Production(_) => {
                 let file_location = self.file_location(file);
                 File::open(file_location)
-                    .context(util::ErrorKind::FileRead(file_location.to_owned())).into()
+                    .context(ErrorKind::FileRead(file_location.to_owned()))
+                    .map_err(Error::from)
             },
             Env::Test(_, ref map) => {
                 match map.get(&file) {
                     Some(data) => data,
-                    None => return Err(util::ErrorKind::NotFound).into()
-                }.try_clone()
+                    None => return Err(ErrorKind::NotFound.into())
+                }
+                    .try_clone()
+                    .context(ErrorKind::Unknown)
+                    .map_err(Error::from)
             }
         }
     }
@@ -62,7 +65,7 @@ impl Env {
         &self,
         file: PiholeFile,
         append: bool
-    ) -> Result<File, util::Error> {
+    ) -> Result<File, Error> {
         match *self {
             Env::Production(_) => {
                 let mut open_options = OpenOptions::new();
@@ -79,16 +82,20 @@ impl Env {
 
                 let file_location = self.file_location(file);
                 open_options.open(file_location)
-                    .context(util::ErrorKind::FileWrite(file_location.to_owned())).into()
+                    .context(ErrorKind::FileWrite(file_location.to_owned()))
+                    .map_err(Error::from)
             },
             Env::Test(_, ref map) => {
                 let file = match map.get(&file) {
                     Some(data) => data,
-                    None => return Err(util::ErrorKind::NotFound).into()
-                }.try_clone()?;
+                    None => return Err(ErrorKind::NotFound.into())
+                }
+                    .try_clone()
+                    .context(ErrorKind::Unknown)?;
 
                 if !append {
-                    file.set_len(0)?;
+                    file.set_len(0)
+                        .context(ErrorKind::Unknown)?;
                 }
 
                 Ok(file)

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -79,7 +79,7 @@ impl Env {
 
                 let file_location = self.file_location(file);
                 open_options.open(file_location)
-                    .context(util::ErrorKind::FileRead(file_location.to_owned())).into()
+                    .context(util::ErrorKind::FileWrite(file_location.to_owned())).into()
             },
             Env::Test(_, ref map) => {
                 let file = match map.get(&file) {

--- a/src/dns/add_list.rs
+++ b/src/dns/add_list.rs
@@ -8,12 +8,12 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-use config::{Env, PiholeFile};
+use config::Env;
 use dns::common::reload_gravity;
 use dns::list::List;
 use rocket::State;
 use rocket_contrib::Json;
-use util;
+use util::{Reply, reply_success};
 use auth::User;
 use ftl::FtlConnectionType;
 
@@ -29,7 +29,7 @@ pub fn add_whitelist(
     _auth: User,
     env: State<Env>,
     domain_input: Json<DomainInput>
-) -> util::Reply {
+) -> Reply {
     let domain = &domain_input.0.domain;
 
     // We need to add it to the whitelist and remove it from the blacklist
@@ -37,8 +37,8 @@ pub fn add_whitelist(
     List::Black.try_remove(domain, &env)?;
 
     // At this point, since we haven't hit an error yet, reload gravity
-    reload_gravity(PiholeFile::Whitelist, &env)?;
-    util::reply_success()
+    reload_gravity(List::White, &env)?;
+    reply_success()
 }
 
 /// Add a domain to the blacklist
@@ -47,7 +47,7 @@ pub fn add_blacklist(
     _auth: User,
     env: State<Env>,
     domain_input: Json<DomainInput>
-) -> util::Reply {
+) -> Reply {
     let domain = &domain_input.0.domain;
 
     // We need to add it to the blacklist and remove it from the whitelist
@@ -55,8 +55,8 @@ pub fn add_blacklist(
     List::White.try_remove(domain, &env)?;
 
     // At this point, since we haven't hit an error yet, reload gravity
-    reload_gravity(PiholeFile::Blacklist, &env)?;
-    util::reply_success()
+    reload_gravity(List::Black, &env)?;
+    reply_success()
 }
 
 /// Add a domain to the regex list
@@ -66,7 +66,7 @@ pub fn add_regexlist(
     env: State<Env>,
     ftl: State<FtlConnectionType>,
     domain_input: Json<DomainInput>
-) -> util::Reply {
+) -> Reply {
     let domain = &domain_input.0.domain;
 
     // We only need to add it to the regex list
@@ -74,7 +74,7 @@ pub fn add_regexlist(
 
     // At this point, since we haven't hit an error yet, tell FTL to recompile regex
     ftl.connect("recompile-regex")?.expect_eom()?;
-    util::reply_success()
+    reply_success()
 }
 
 #[cfg(test)]

--- a/src/dns/delete_list.rs
+++ b/src/dns/delete_list.rs
@@ -8,28 +8,28 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-use config::{Env, PiholeFile};
+use config::Env;
 use dns::common::reload_gravity;
 use dns::list::List;
 use rocket::State;
-use util;
+use util::{Reply, reply_success};
 use auth::User;
 use ftl::FtlConnectionType;
 
 /// Delete a domain from the whitelist
 #[delete("/dns/whitelist/<domain>")]
-pub fn delete_whitelist(_auth: User, env: State<Env>, domain: String) -> util::Reply {
+pub fn delete_whitelist(_auth: User, env: State<Env>, domain: String) -> Reply {
     List::White.remove(&domain, &env)?;
-    reload_gravity(PiholeFile::Whitelist, &env)?;
-    util::reply_success()
+    reload_gravity(List::White, &env)?;
+    reply_success()
 }
 
 /// Delete a domain from the blacklist
 #[delete("/dns/blacklist/<domain>")]
-pub fn delete_blacklist(_auth: User, env: State<Env>, domain: String) -> util::Reply {
+pub fn delete_blacklist(_auth: User, env: State<Env>, domain: String) -> Reply {
     List::Black.remove(&domain, &env)?;
-    reload_gravity(PiholeFile::Blacklist, &env)?;
-    util::reply_success()
+    reload_gravity(List::Black, &env)?;
+    reply_success()
 }
 
 /// Delete a domain from the regex list
@@ -39,10 +39,10 @@ pub fn delete_regexlist(
     env: State<Env>,
     ftl: State<FtlConnectionType>,
     domain: String
-) -> util::Reply {
+) -> Reply {
     List::Regex.remove(&domain, &env)?;
     ftl.connect("recompile-regex")?.expect_eom()?;
-    util::reply_success()
+    reply_success()
 }
 
 #[cfg(test)]

--- a/src/dns/get_list.rs
+++ b/src/dns/get_list.rs
@@ -11,24 +11,24 @@
 use config::Env;
 use dns::list::List;
 use rocket::State;
-use util;
+use util::{Reply, reply_data};
 
 /// Get the Whitelist domains
 #[get("/dns/whitelist")]
-pub fn get_whitelist(env: State<Env>) -> util::Reply {
-    util::reply_data(List::White.get(&env)?)
+pub fn get_whitelist(env: State<Env>) -> Reply {
+    reply_data(List::White.get(&env)?)
 }
 
 /// Get the Blacklist domains
 #[get("/dns/blacklist")]
-pub fn get_blacklist(env: State<Env>) -> util::Reply {
-    util::reply_data(List::Black.get(&env)?)
+pub fn get_blacklist(env: State<Env>) -> Reply {
+    reply_data(List::Black.get(&env)?)
 }
 
 /// Get the Regex list domains
 #[get("/dns/regexlist")]
-pub fn get_regexlist(env: State<Env>) -> util::Reply {
-    util::reply_data(List::Regex.get(&env)?)
+pub fn get_regexlist(env: State<Env>) -> Reply {
+    reply_data(List::Regex.get(&env)?)
 }
 
 #[cfg(test)]

--- a/src/dns/list.rs
+++ b/src/dns/list.rs
@@ -11,7 +11,7 @@
 use config::{Env, PiholeFile};
 use dns::common::{is_valid_domain, is_valid_regex};
 use failure::ResultExt;
-use std::io::{self, BufReader, BufWriter};
+use std::io::{BufReader, BufWriter};
 use std::io::prelude::*;
 use util::{Error, ErrorKind};
 
@@ -42,7 +42,7 @@ impl List {
         let file = match env.read_file(self.file()) {
             Ok(f) => f,
             Err(e) => {
-                if e.kind() == io::ErrorKind::NotFound {
+                if e.kind() == ErrorKind::NotFound {
                     // If the file is not found, then the list is empty
                     return Ok(Vec::new());
                 } else {
@@ -64,12 +64,12 @@ impl List {
     pub fn add(&self, domain: &str, env: &Env) -> Result<(), Error> {
         // Check if it's a valid domain before doing anything
         if !self.accepts(domain) {
-            return Err(ErrorKind::InvalidDomain).into();
+            return Err(ErrorKind::InvalidDomain.into());
         }
 
         // Check if the domain is already in the list
         if self.get(env)?.contains(&domain.to_owned()) {
-            return Err(ErrorKind::AlreadyExists).into();
+            return Err(ErrorKind::AlreadyExists.into());
         }
 
         // Open the list file in append mode (and create it if it doesn't exist)
@@ -91,7 +91,7 @@ impl List {
             Ok(ok) => Ok(ok),
             Err(e) => {
                 // Ignore NotFound errors
-                if e == ErrorKind::NotFound {
+                if e.kind() == ErrorKind::NotFound {
                     Ok(())
                 } else {
                     Err(e)
@@ -104,13 +104,13 @@ impl List {
     pub fn remove(&self, domain: &str, env: &Env) -> Result<(), Error> {
         // Check if it's a valid domain before doing anything
         if !self.accepts(domain) {
-            return Err(ErrorKind::InvalidDomain).into();
+            return Err(ErrorKind::InvalidDomain.into());
         }
 
         // Check if the domain is not in the list
         let domains = self.get(env)?;
         if !domains.contains(&domain.to_owned()) {
-            return Err(ErrorKind::NotFound).into();
+            return Err(ErrorKind::NotFound.into());
         }
 
         // Open the list file (and create it if it doesn't exist). This will truncate the list so

--- a/src/dns/status.rs
+++ b/src/dns/status.rs
@@ -12,11 +12,11 @@ use config::{Env, PiholeFile};
 use std::io::{BufRead, BufReader};
 use std::fs::File;
 use rocket::State;
-use util;
+use util::{Reply, reply_data};
 
 /// Get the DNS blocking status
 #[get("/dns/status")]
-pub fn status(env: State<Env>) -> util::Reply {
+pub fn status(env: State<Env>) -> Reply {
     let status = match env.read_file(PiholeFile::DnsmasqMainConfig) {
         Ok(file) => check_for_gravity(file),
 
@@ -24,7 +24,7 @@ pub fn status(env: State<Env>) -> util::Reply {
         Err(_) => "unknown"
     };
 
-    util::reply_data(json!({
+    reply_data(json!({
         "status": status
     }))
 }

--- a/src/ftl.rs
+++ b/src/ftl.rs
@@ -14,7 +14,7 @@ use std::io::prelude::*;
 use std::io::{BufReader, Cursor};
 use std::collections::HashMap;
 use rmp::decode;
-
+use failure::ResultExt;
 use util;
 
 /// The location of the FTL socket
@@ -68,52 +68,52 @@ impl FtlConnectionType {
 
 impl<'test> FtlConnection<'test> {
     /// We expect an end of message (EOM) response when FTL has finished sending data
-    pub fn expect_eom(&mut self) -> Result<(), String> {
+    pub fn expect_eom(&mut self) -> Result<(), util::Error> {
         let mut buffer: [u8; 1] = [0];
 
         // Read exactly 1 byte
         match self.0.read_exact(&mut buffer) {
             Ok(_) => (),
-            Err(e) => return Err(e.description().to_string())
+            Err(e) => return Err(util::ErrorKind::FtlReadError).into()
         }
 
         // Check if it was the EOM byte
         if buffer[0] != 0xc1 {
-            return Err(format!("Expected EOM (0xc1), got {:2x}", buffer[0]));
+            return Err(util::ErrorKind::FtlReadError).into();
         }
 
         Ok(())
     }
 
     /// Read in a bool value
-    pub fn read_bool(&mut self) -> Result<bool, decode::ValueReadError> {
-        decode::read_bool(&mut self.0)
+    pub fn read_bool(&mut self) -> Result<bool, util::Error> {
+        decode::read_bool(&mut self.0).context(util::ErrorKind::FtlReadError).into()
     }
 
     /// Read in a u8 (unsigned byte) value
-    pub fn read_u8(&mut self) -> Result<u8, decode::ValueReadError> {
-        decode::read_u8(&mut self.0)
+    pub fn read_u8(&mut self) -> Result<u8, util::Error> {
+        decode::read_u8(&mut self.0).context(util::ErrorKind::FtlReadError).into()
     }
 
     /// Read in an i32 (signed int) value
-    pub fn read_i32(&mut self) -> Result<i32, decode::ValueReadError> {
-        decode::read_i32(&mut self.0)
+    pub fn read_i32(&mut self) -> Result<i32, util::Error> {
+        decode::read_i32(&mut self.0).context(util::ErrorKind::FtlReadError).into()
     }
 
     /// Read in an f32 (float) value
-    pub fn read_f32(&mut self) -> Result<f32, decode::ValueReadError> {
-        decode::read_f32(&mut self.0)
+    pub fn read_f32(&mut self) -> Result<f32, util::Error> {
+        decode::read_f32(&mut self.0).context(util::ErrorKind::FtlReadError).into()
     }
 
     /// Read in a string using the buffer
-    pub fn read_str<'r>(&mut self, buffer: &'r mut [u8])
-            -> Result<&'r str, decode::DecodeStringError<'r>> {
+    pub fn read_str(&mut self, buffer: &mut [u8]) -> Result<&str, util::Error> {
         decode::read_str(&mut self.0, buffer)
+            .context(util::ErrorKind::FtlReadError).into()
     }
 
     /// Read in the length of the upcoming map (unsigned int)
-    pub fn read_map_len(&mut self) -> Result<u32, decode::ValueReadError> {
-        decode::read_map_len(&mut self.0)
+    pub fn read_map_len(&mut self) -> Result<u32, util::Error> {
+        decode::read_map_len(&mut self.0).context(util::ErrorKind::FtlReadError).into()
     }
 }
 

--- a/src/ftl.rs
+++ b/src/ftl.rs
@@ -9,13 +9,12 @@
 *  Please see LICENSE file for your rights under this license. */
 
 use std::os::unix::net::UnixStream;
-use std::error::Error;
 use std::io::prelude::*;
 use std::io::{BufReader, Cursor};
 use std::collections::HashMap;
-use rmp::decode;
-use failure::ResultExt;
-use util;
+use rmp::{Marker, decode::{self, ValueReadError, DecodeStringError}};
+use failure::{Fail, ResultExt};
+use util::{Error, ErrorKind};
 
 /// The location of the FTL socket
 const SOCKET_LOCATION: &'static str = "/var/run/pihole/FTL.sock";
@@ -36,18 +35,19 @@ pub enum FtlConnectionType {
 
 impl FtlConnectionType {
     /// Connect to FTL and run the specified command
-    pub fn connect(&self, command: &str) -> Result<FtlConnection, util::Error> {
+    pub fn connect(&self, command: &str) -> Result<FtlConnection, Error> {
         // Determine the type of connection to create
         match *self {
             FtlConnectionType::Socket => {
                 // Try to connect to FTL
                 let mut stream = match UnixStream::connect(SOCKET_LOCATION) {
                     Ok(s) => s,
-                    Err(_) => return Err(util::Error::FtlConnectionFail)
+                    Err(_) => return Err(ErrorKind::FtlConnectionFail.into())
                 };
 
                 // Send the command
-                stream.write_all(format!(">{}\n", command).as_bytes())?;
+                stream.write_all(format!(">{}\n", command).as_bytes())
+                    .context(ErrorKind::FtlConnectionFail)?;
 
                 // Return the connection so the API can read the response
                 Ok(FtlConnection(Box::new(BufReader::new(stream))))
@@ -58,7 +58,7 @@ impl FtlConnectionType {
                     // Try to get the testing data for this command
                     match map.get(command) {
                         Some(data) => data,
-                        None => return Err(util::Error::FtlConnectionFail)
+                        None => return Err(ErrorKind::FtlConnectionFail.into())
                     }
                 ))))
             }
@@ -67,53 +67,90 @@ impl FtlConnectionType {
 }
 
 impl<'test> FtlConnection<'test> {
+    fn handle_eom_value<T>(result: Result<T, ValueReadError>) -> Result<T, Error> {
+        result.map_err(|e| {
+            if let ValueReadError::TypeMismatch(marker) = e {
+                if marker == Marker::Reserved {
+                    // Received EOM
+                    return e.context(ErrorKind::FtlEomError).into();
+                }
+            }
+
+            e.context(ErrorKind::FtlReadError).into()
+        })
+    }
+
+    fn handle_eom_str<T>(result: Result<T, DecodeStringError>) -> Result<T, Error> {
+        result.map_err(|e| {
+            if let DecodeStringError::TypeMismatch(ref marker) = e {
+                if *marker == Marker::Reserved {
+                    // Received EOM
+                    return ErrorKind::FtlEomError.into();
+                }
+            }
+
+            ErrorKind::FtlReadError.into()
+        })
+    }
+
     /// We expect an end of message (EOM) response when FTL has finished sending data
-    pub fn expect_eom(&mut self) -> Result<(), util::Error> {
+    pub fn expect_eom(&mut self) -> Result<(), Error> {
         let mut buffer: [u8; 1] = [0];
 
         // Read exactly 1 byte
         match self.0.read_exact(&mut buffer) {
             Ok(_) => (),
-            Err(e) => return Err(util::ErrorKind::FtlReadError).into()
+            Err(e) => return Err(e.context(ErrorKind::FtlReadError).into())
         }
 
         // Check if it was the EOM byte
         if buffer[0] != 0xc1 {
-            return Err(util::ErrorKind::FtlReadError).into();
+            return Err(ErrorKind::FtlReadError.into());
         }
 
         Ok(())
     }
 
     /// Read in a bool value
-    pub fn read_bool(&mut self) -> Result<bool, util::Error> {
-        decode::read_bool(&mut self.0).context(util::ErrorKind::FtlReadError).into()
+    pub fn read_bool(&mut self) -> Result<bool, Error> {
+        FtlConnection::handle_eom_value(
+            decode::read_bool(&mut self.0)
+        )
     }
 
     /// Read in a u8 (unsigned byte) value
-    pub fn read_u8(&mut self) -> Result<u8, util::Error> {
-        decode::read_u8(&mut self.0).context(util::ErrorKind::FtlReadError).into()
+    pub fn read_u8(&mut self) -> Result<u8, Error> {
+        FtlConnection::handle_eom_value(
+            decode::read_u8(&mut self.0)
+        )
     }
 
     /// Read in an i32 (signed int) value
-    pub fn read_i32(&mut self) -> Result<i32, util::Error> {
-        decode::read_i32(&mut self.0).context(util::ErrorKind::FtlReadError).into()
+    pub fn read_i32(&mut self) -> Result<i32, Error> {
+        FtlConnection::handle_eom_value(
+            decode::read_i32(&mut self.0)
+        )
     }
 
     /// Read in an f32 (float) value
-    pub fn read_f32(&mut self) -> Result<f32, util::Error> {
-        decode::read_f32(&mut self.0).context(util::ErrorKind::FtlReadError).into()
+    pub fn read_f32(&mut self) -> Result<f32, Error> {
+        FtlConnection::handle_eom_value(
+            decode::read_f32(&mut self.0)
+        )
     }
 
     /// Read in a string using the buffer
-    pub fn read_str(&mut self, buffer: &mut [u8]) -> Result<&str, util::Error> {
-        decode::read_str(&mut self.0, buffer)
-            .context(util::ErrorKind::FtlReadError).into()
+    pub fn read_str<'a>(&mut self, buffer: &'a mut [u8]) -> Result<&'a str, Error> {
+        FtlConnection::handle_eom_str(
+            decode::read_str(&mut self.0, buffer)
+        )
     }
 
     /// Read in the length of the upcoming map (unsigned int)
-    pub fn read_map_len(&mut self) -> Result<u32, util::Error> {
-        decode::read_map_len(&mut self.0).context(util::ErrorKind::FtlReadError).into()
+    pub fn read_map_len(&mut self) -> Result<u32, Error> {
+        FtlConnection::handle_eom_value(
+            decode::read_map_len(&mut self.0)
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ extern crate serde_derive;
 extern crate rust_embed;
 extern crate toml;
 extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 
 pub use setup::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate rust_embed;
 extern crate toml;
+extern crate failure;
 
 pub use setup::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,5 +11,7 @@
 extern crate pihole_api;
 
 fn main() {
-    pihole_api::start();
+    if let Err(e) = pihole_api::start() {
+        e.print_stacktrace();
+    }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -29,12 +29,12 @@ const CONFIG_LOCATION: &'static str = "/etc/pihole/API.toml";
 
 #[error(404)]
 fn not_found() -> util::Error {
-    util::Error::NotFound
+    util::ErrorKind::NotFound.into()
 }
 
 #[error(401)]
 fn unauthorized() -> util::Error {
-    util::Error::Unauthorized
+    util::ErrorKind::Unauthorized.into()
 }
 
 /// Run the API normally (connect to FTL over the socket)

--- a/src/setup_vars.rs
+++ b/src/setup_vars.rs
@@ -9,22 +9,14 @@
 *  Please see LICENSE file for your rights under this license. */
 
 use config::{Env, PiholeFile};
-use failure::Fail;
 use std::io::BufReader;
 use std::io::prelude::*;
-use util::{Error, ErrorKind};
+use util::Error;
 
 /// Read in a value from setupVars.conf
 pub fn read_setup_vars(entry: &str, env: &Env) -> Result<Option<String>, Error> {
     // Open setupVars.conf
-    let reader = BufReader::new(
-        env.read_file(PiholeFile::SetupVars)
-            .map_err(|e| {
-                e.context(ErrorKind::FileRead(
-                    env.config().file_location(PiholeFile::SetupVars).to_owned()
-                ))
-            })?
-    );
+    let reader = BufReader::new(env.read_file(PiholeFile::SetupVars)?);
 
     // Check every line for the key (filter out lines which could not be read)
     for line in reader.lines().filter_map(|item| item.ok()) {

--- a/src/setup_vars.rs
+++ b/src/setup_vars.rs
@@ -11,11 +11,19 @@
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 use config::{Env, PiholeFile};
+use util;
 
 /// Read in a value from setupVars.conf
-pub fn read_setup_vars(entry: &str, env: &Env) -> io::Result<Option<String>> {
+pub fn read_setup_vars(entry: &str, env: &Env) -> Result<Option<String>, util::Error> {
     // Open setupVars.conf
-    let reader = BufReader::new(env.read_file(PiholeFile::SetupVars)?);
+    let reader = BufReader::new(
+        env.read_file(PiholeFile::SetupVars)
+            .map_err(|e| {
+                e.context(util::ErrorKind::FileRead(
+                    env.config().file_location(PiholeFile::SetupVars).to_owned()
+                ))
+            })?
+    );
 
     // Check every line for the key (filter out lines which could not be read)
     for line in reader.lines().filter_map(|item| item.ok()) {

--- a/src/setup_vars.rs
+++ b/src/setup_vars.rs
@@ -8,18 +8,19 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-use std::io::prelude::*;
-use std::io::{self, BufReader};
 use config::{Env, PiholeFile};
-use util;
+use failure::Fail;
+use std::io::BufReader;
+use std::io::prelude::*;
+use util::{Error, ErrorKind};
 
 /// Read in a value from setupVars.conf
-pub fn read_setup_vars(entry: &str, env: &Env) -> Result<Option<String>, util::Error> {
+pub fn read_setup_vars(entry: &str, env: &Env) -> Result<Option<String>, Error> {
     // Open setupVars.conf
     let reader = BufReader::new(
         env.read_file(PiholeFile::SetupVars)
             .map_err(|e| {
-                e.context(util::ErrorKind::FileRead(
+                e.context(ErrorKind::FileRead(
                     env.config().file_location(PiholeFile::SetupVars).to_owned()
                 ))
             })?

--- a/src/stats/over_time_history.rs
+++ b/src/stats/over_time_history.rs
@@ -10,25 +10,24 @@
 
 use ftl::{FtlConnectionType, FtlConnection};
 use rocket::State;
-use util;
-use rmp::decode;
+use util::{Reply, Error, reply_data};
 
 /// Get the query history over time (separated into blocked and not blocked)
 #[get("/stats/overTime/history")]
-pub fn over_time_history(ftl: State<FtlConnectionType>) -> util::Reply {
+pub fn over_time_history(ftl: State<FtlConnectionType>) -> Reply {
     let mut con = ftl.connect("overTime")?;
 
     let domains_over_time = get_over_time_data(&mut con)?;
     let blocked_over_time = get_over_time_data(&mut con)?;
 
-    util::reply_data(json!({
+    reply_data(json!({
         "domains_over_time": domains_over_time,
         "blocked_over_time": blocked_over_time
     }))
 }
 
 /// Read in some time data (represented by FTL as a map of ints to ints)
-fn get_over_time_data(ftl: &mut FtlConnection) -> Result<Vec<TimeStep>, decode::ValueReadError> {
+fn get_over_time_data(ftl: &mut FtlConnection) -> Result<Vec<TimeStep>, Error> {
     // Read in the length of the data to optimize memory usage
     let map_len = ftl.read_map_len()? as usize;
 

--- a/src/stats/summary.rs
+++ b/src/stats/summary.rs
@@ -10,11 +10,11 @@
 
 use ftl::FtlConnectionType;
 use rocket::State;
-use util;
+use util::{Reply, reply_data};
 
 /// Get the summary data
 #[get("/stats/summary")]
-pub fn get_summary(ftl: State<FtlConnectionType>) -> util::Reply {
+pub fn get_summary(ftl: State<FtlConnectionType>) -> Reply {
     let mut con = ftl.connect("stats")?;
 
     // Read in the data
@@ -34,7 +34,7 @@ pub fn get_summary(ftl: State<FtlConnectionType>) -> util::Reply {
     };
     con.expect_eom()?;
 
-    util::reply_data(json!({
+    reply_data(json!({
         "domains_blocked": domains_blocked,
         "total_queries": total_queries,
         "blocked_queries": blocked_queries,

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,8 +26,11 @@ pub fn reply<D: Serialize>(data: ReplyType<D>, status: Status) -> Reply {
     let json_data = match data {
         ReplyType::Data(d) => json!(d),
         ReplyType::Error(e) => {
-            // Print out the error
-            e.print_stacktrace();
+            // Only print out the error if it's not a common error
+            match e.kind() {
+                ErrorKind::Unauthorized | ErrorKind::NotFound => (),
+                _ => e.print_stacktrace()
+            }
 
             json!({
                 "error": {

--- a/src/util.rs
+++ b/src/util.rs
@@ -90,6 +90,8 @@ pub enum ErrorKind {
     Unauthorized,
     #[fail(display = "Error reading from {}", _0)]
     FileRead(String),
+    #[fail(display = "Error writing to {}", _0)]
+    FileWrite(String),
     #[fail(display = "Error parsing the config")]
     ConfigParsingError
 }
@@ -129,11 +131,15 @@ impl ErrorKind {
             ErrorKind::Unknown => "unknown",
             ErrorKind::GravityError => "gravity_error",
             ErrorKind::FtlConnectionFail => "ftl_connection_fail",
+            ErrorKind::FtlReadError => "ftl_read_error",
             ErrorKind::NotFound => "not_found",
             ErrorKind::AlreadyExists => "already_exists",
             ErrorKind::InvalidDomain => "invalid_domain",
             ErrorKind::BadRequest => "bad_request",
-            ErrorKind::Unauthorized => "unauthorized"
+            ErrorKind::Unauthorized => "unauthorized",
+            ErrorKind::FileRead(_) => "file_read",
+            ErrorKind::FileWrite(_) => "file_write",
+            ErrorKind::ConfigParsingError => "config_parsing_error"
         }
     }
 
@@ -143,11 +149,15 @@ impl ErrorKind {
             ErrorKind::Unknown => Status::InternalServerError,
             ErrorKind::GravityError => Status::InternalServerError,
             ErrorKind::FtlConnectionFail => Status::InternalServerError,
+            ErrorKind::FtlReadError => Status::InternalServerError,
             ErrorKind::NotFound => Status::NotFound,
             ErrorKind::AlreadyExists => Status::Conflict,
             ErrorKind::InvalidDomain => Status::BadRequest,
             ErrorKind::BadRequest => Status::BadRequest,
-            ErrorKind::Unauthorized => Status::Unauthorized
+            ErrorKind::Unauthorized => Status::Unauthorized,
+            ErrorKind::FileRead(_) => Status::InternalServerErrror,
+            ErrorKind::FileWrite(_) => Status::InternalServerError,
+            ErrorKind::ConfigParsingError => Status::InternalServerError
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -89,7 +89,9 @@ pub enum ErrorKind {
     #[fail(display = "Unauthorized")]
     Unauthorized,
     #[fail(display = "Error reading from {}", _0)]
-    FileRead(String)
+    FileRead(String),
+    #[fail(display = "Error parsing the config")]
+    ConfigParsingError
 }
 
 impl Error {

--- a/src/util.rs
+++ b/src/util.rs
@@ -108,7 +108,8 @@ impl Error {
         eprintln!("Error: {}", self);
 
         // Only print the backtrace if requested, to avoid a gap between error and causes
-        if env::var("RUST_BACKTRACE").is_ok() {
+        let backtrace_enabled = env::var("RUST_BACKTRACE").is_ok();
+        if backtrace_enabled {
             if let Some(backtrace) = self.backtrace() {
                 eprintln!("{}", backtrace);
             }
@@ -118,8 +119,10 @@ impl Error {
         for (i, cause) in self.causes().skip(1).enumerate() {
             eprintln!("Cause #{}: {}", i+1, cause);
 
-            if let Some(backtrace) = cause.backtrace() {
-                eprintln!("{}", backtrace);
+            if backtrace_enabled {
+                if let Some(backtrace) = cause.backtrace() {
+                    eprintln!("{}", backtrace);
+                }
             }
         }
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,23 +8,24 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-use rocket::State;
 use config::{Env, PiholeFile};
+use failure::ResultExt;
 use ftl::FtlConnectionType;
-use util;
+use rocket::State;
 use std::io::Read;
-use web::WebAssets;
 use std::str;
+use util::{Error, ErrorKind, Reply, reply_data};
+use web::WebAssets;
 
 /// Get the versions of all Pi-hole systems
 #[get("/version")]
-pub fn version(env: State<Env>, ftl: State<FtlConnectionType>) -> util::Reply {
+pub fn version(env: State<Env>, ftl: State<FtlConnectionType>) -> Reply {
     let core_version = read_core_version(&env).unwrap_or_default();
     let web_version = read_web_version().unwrap_or_default();
     let ftl_version = read_ftl_version(&ftl).unwrap_or_default();
     let api_version = read_api_version();
 
-    util::reply_data(json!({
+    reply_data(json!({
         "core": core_version,
         "web": web_version,
         "ftl": ftl_version,
@@ -42,7 +43,7 @@ fn read_api_version() -> Version {
 }
 
 /// Read FTL version information from FTL's API
-fn read_ftl_version(ftl: &FtlConnectionType) -> Result<Version, util::Error> {
+fn read_ftl_version(ftl: &FtlConnectionType) -> Result<Version, Error> {
     let mut con = ftl.connect("version")?;
     let mut str_buffer = [0u8; 4096];
 
@@ -62,16 +63,17 @@ fn read_ftl_version(ftl: &FtlConnectionType) -> Result<Version, util::Error> {
 }
 
 /// Read Web version information from the `VERSION` file in the web assets.
-fn read_web_version() -> Result<Version, util::Error> {
-    let version_raw = WebAssets::get("VERSION").ok_or(util::Error::Unknown)?;
-    let version_str = str::from_utf8(&version_raw)?;
+fn read_web_version() -> Result<Version, Error> {
+    let version_raw = WebAssets::get("VERSION").ok_or(ErrorKind::Unknown)?;
+    let version_str = str::from_utf8(&version_raw)
+        .context(ErrorKind::Unknown)?;
 
     parse_web_version(version_str)
 }
 
 /// Parse Web version information from the string.
 /// The string should be in the format "TAG BRANCH COMMIT".
-fn parse_web_version(version_str: &str) -> Result<Version, util::Error> {
+fn parse_web_version(version_str: &str) -> Result<Version, Error> {
     // Trim to remove possible newline
     let version_split: Vec<&str> = version_str
         .trim_right_matches("\n")
@@ -79,7 +81,7 @@ fn parse_web_version(version_str: &str) -> Result<Version, util::Error> {
         .collect();
 
     if version_split.len() != 3 {
-        return Err(util::Error::Unknown);
+        return Err(ErrorKind::Unknown.into());
     }
 
     Ok(Version {
@@ -90,14 +92,20 @@ fn parse_web_version(version_str: &str) -> Result<Version, util::Error> {
 }
 
 /// Read Core version information from the file system
-fn read_core_version(env: &Env) -> Result<Version, util::Error> {
+fn read_core_version(env: &Env) -> Result<Version, Error> {
     // Read the version files
     let mut local_versions = String::new();
     let mut local_branches = String::new();
     env.read_file(PiholeFile::LocalVersions)?
-        .read_to_string(&mut local_versions)?;
+        .read_to_string(&mut local_versions)
+        .context(ErrorKind::FileRead(
+            env.file_location(PiholeFile::LocalVersions).to_owned()
+        ))?;
     env.read_file(PiholeFile::LocalBranches)?
-        .read_to_string(&mut local_branches)?;
+        .read_to_string(&mut local_branches)
+        .context(ErrorKind::FileRead(
+            env.file_location(PiholeFile::LocalBranches).to_owned()
+        ))?;
 
     // These files are structured as "CORE WEB FTL", but we only want Core's data
     let git_version = local_versions.split(" ").next().unwrap_or_default();
@@ -109,12 +117,12 @@ fn read_core_version(env: &Env) -> Result<Version, util::Error> {
 
 /// Parse version data from the output of `git describe` (stored in `PiholeFile::LocalVersions`).
 /// The string is in the form "TAG-NUMBER-COMMIT", though it could also have "-dirty" at the end.
-fn parse_git_version(git_version: &str, branch: &str) -> Result<Version, util::Error> {
+fn parse_git_version(git_version: &str, branch: &str) -> Result<Version, Error> {
     let split: Vec<&str> = git_version.split("-").collect();
 
     // Could include "-dirty", which would make the length equal 4
     if split.len() < 3 {
-        return Err(util::Error::Unknown);
+        return Err(ErrorKind::Unknown.into());
     }
 
     // Only set the tag if this is the tagged commit (we are 0 commits after the tag)
@@ -137,14 +145,14 @@ struct Version {
 
 #[cfg(test)]
 mod tests {
-    use super::{Version, parse_git_version, parse_web_version, read_ftl_version};
-    use testing::{TestEnvBuilder, write_eom};
-    use config::{PiholeFile, Env, Config};
-    use version::read_core_version;
-    use util;
-    use rmp::encode;
+    use config::{Config, Env, PiholeFile};
     use ftl::FtlConnectionType;
+    use rmp::encode;
     use std::collections::HashMap;
+    use super::{parse_git_version, parse_web_version, read_ftl_version, Version};
+    use testing::{TestEnvBuilder, write_eom};
+    use util::ErrorKind;
+    use version::read_core_version;
 
     #[test]
     fn test_read_ftl_version_dev() {
@@ -162,7 +170,7 @@ mod tests {
         let ftl = FtlConnectionType::Test(map);
 
         assert_eq!(
-            read_ftl_version(&ftl),
+            read_ftl_version(&ftl).map_err(|e| e.kind()),
             Ok(Version {
                 tag: "".to_owned(),
                 branch: "tweak/version-api".to_owned(),
@@ -187,7 +195,7 @@ mod tests {
         let ftl = FtlConnectionType::Test(map);
 
         assert_eq!(
-            read_ftl_version(&ftl),
+            read_ftl_version(&ftl).map_err(|e| e.kind()),
             Ok(Version {
                 tag: "v4.0".to_owned(),
                 branch: "master".to_owned(),
@@ -199,7 +207,7 @@ mod tests {
     #[test]
     fn test_parse_web_version_dev() {
         assert_eq!(
-            parse_web_version(" development d2037fd"),
+            parse_web_version(" development d2037fd").map_err(|e| e.kind()),
             Ok(Version {
                 tag: "".to_owned(),
                 branch: "development".to_owned(),
@@ -211,7 +219,7 @@ mod tests {
     #[test]
     fn test_parse_web_version_release() {
         assert_eq!(
-            parse_web_version("v1.0.0 master abcdefg"),
+            parse_web_version("v1.0.0 master abcdefg").map_err(|e| e.kind()),
             Ok(Version {
                 tag: "v1.0.0".to_owned(),
                 branch: "master".to_owned(),
@@ -222,13 +230,16 @@ mod tests {
 
     #[test]
     fn test_parse_web_version_invalid() {
-        assert_eq!(parse_web_version("invalid data"), Err(util::Error::Unknown));
+        assert_eq!(
+            parse_web_version("invalid data").map_err(|e| e.kind()),
+            Err(ErrorKind::Unknown)
+        );
     }
 
     #[test]
     fn test_parse_web_version_newline() {
         assert_eq!(
-            parse_web_version(" development d2037fd\n"),
+            parse_web_version(" development d2037fd\n").map_err(|e| e.kind()),
             Ok(Version {
                 tag: "".to_owned(),
                 branch: "development".to_owned(),
@@ -254,7 +265,7 @@ mod tests {
         );
 
         assert_eq!(
-            read_core_version(&test_env),
+            read_core_version(&test_env).map_err(|e| e.kind()),
             Ok(Version {
                 tag: "".to_owned(),
                 branch: "development".to_owned(),
@@ -279,13 +290,16 @@ mod tests {
                 .build()
         );
 
-        assert_eq!(read_core_version(&test_env), Err(util::Error::Unknown));
+        assert_eq!(
+            read_core_version(&test_env).map_err(|e| e.kind()),
+            Err(ErrorKind::Unknown)
+        );
     }
 
     #[test]
     fn test_parse_git_version_release() {
         assert_eq!(
-            parse_git_version("v3.3.1-0-gfbee18e", "master"),
+            parse_git_version("v3.3.1-0-gfbee18e", "master").map_err(|e| e.kind()),
             Ok(Version {
                 tag: "v3.3.1".to_owned(),
                 branch: "master".to_owned(),
@@ -297,7 +311,8 @@ mod tests {
     #[test]
     fn test_parse_git_version_dev() {
         assert_eq!(
-            parse_git_version("v3.3.1-222-gd9c924b", "development"),
+            parse_git_version("v3.3.1-222-gd9c924b", "development")
+                .map_err(|e| e.kind()),
             Ok(Version {
                 tag: "".to_owned(),
                 branch: "development".to_owned(),
@@ -309,15 +324,16 @@ mod tests {
     #[test]
     fn test_parse_git_version_invalid() {
         assert_eq!(
-            parse_git_version("invalid data", "branch"),
-            Err(util::Error::Unknown)
+            parse_git_version("invalid data", "branch").map_err(|e| e.kind()),
+            Err(ErrorKind::Unknown)
         );
     }
 
     #[test]
     fn test_parse_git_version_dirty() {
         assert_eq!(
-            parse_git_version("v3.3.1-222-gd9c924b-dirty", "development"),
+            parse_git_version("v3.3.1-222-gd9c924b-dirty", "development")
+                .map_err(|e| e.kind()),
             Ok(Version {
                 tag: "".to_owned(),
                 branch: "development".to_owned(),


### PR DESCRIPTION
Closes #25 

This does not change the errors sent to the client, just the logged errors.

Some examples of errors:
```
$ pihole-API
Error: Error reading from /etc/pihole/setupVars.conf
Cause #1: No such file or directory (os error 2)
```
```
$ RUST_BACKTRACE=1 pihole-API
Error: Error reading from /etc/pihole/setupVars.conf
stack backtrace:
   0:     0x558eeeedce6c - backtrace::backtrace::trace::h30d324ce092962b2
   1:     0x558eeeeda291 - failure::backtrace::Backtrace::new::h99b2407c016107b2
   2:     0x558eeeed371d - <core::result::Result<T, E> as failure::result_ext::ResultExt<T, E>>::context::h737066d584c61fdf
   3:     0x558eeeed3593 - pihole_api::config::env::Env::read_file::h5bb299c4526921d7
   4:     0x558eeeeac28d - pihole_api::setup::start::h42e261af1ff81e3b
   5:     0x558eeee5fcb1 - pihole_api::main::h7ead3686e4fa2ece
   6:     0x558eef0034e2 - std::rt::lang_start::{{closure}}::hcf744fcbbb64976b
   7:     0x558eeee600c9 - main
   8:     0x7f7f0f12218a - __libc_start_main
   9:     0x558eeee5f8d9 - _start
  10:                0x0 - <unknown>
Cause #1: No such file or directory (os error 2)
```

And an error triggered by an API request:
```
Error: Error reading from /etc/pihole/whitelist.txt
Cause #1: No such file or directory (os error 2)
```

And some errors triggered by API requests with `RUST_BACKTRACE=1`:
```
Error: Failed to connect to FTL
stack backtrace:
   0:   0x51c0c3 - backtrace::backtrace::trace::hfb94e9b70179ab7b
   1:   0x51900f - failure::backtrace::Backtrace::new::hb3963dd5fc5c1a6e
   2:   0x4ea2bf - pihole_api::ftl::FtlConnectionType::connect::hf26088ce4fda53de
   3:   0x4f8927 - pihole_api::stats::summary::rocket_route_fn_get_summary::hcc8893e2d7c7a37b
   4:   0x567293 - rocket::rocket::Rocket::dispatch::h0b6813b25f332266
   5:   0x563283 - <rocket::rocket::Rocket as hyper::server::Handler>::handle::h90337c6a29041c8a
   6:   0x57f1c3 - <hyper::server::Worker<H>>::handle_connection::h20e08e2c2f0b24cd
   7:   0x557223 - hyper::server::listener::spawn_with::{{closure}}::hc8bf134e303c9e0c
   8:   0x556f97 - std::sys_common::backtrace::__rust_begin_short_backtrace::ha682d6d382a1107b
   9:   0x559a9f - <F as alloc::boxed::FnBox<A>>::call_box::h1552b33ac6668997
  10:   0x649a13 - <alloc::boxed::Box<alloc::boxed::FnBox<A, Output$u3d$R$GT$$u20$$u2b$$u20$$u27$a$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$::call_once::h4a163f038fb055cf
```
```
Error: Error reading from /etc/pihole/whitelist.txt
stack backtrace:
   0:   0x51d0c3 - backtrace::backtrace::trace::hfb94e9b70179ab7b
   1:   0x51a00f - failure::backtrace::Backtrace::new::hb3963dd5fc5c1a6e
   2:   0x51312b - <core::result::Result<T, E> as failure::result_ext::ResultExt<T, E>>::context::h154f055be3e36c38
   3:   0x512f7f - pihole_api::config::env::Env::read_file::h03c08899bfcb2e0e
   4:   0x4d1dfb - pihole_api::dns::list::List::get::hebbc84cfaa7d5591
   5:   0x50903b - pihole_api::dns::get_list::rocket_route_fn_get_whitelist::hc92d612f79bb623f
   6:   0x568293 - rocket::rocket::Rocket::dispatch::h0b6813b25f332266
   7:   0x564283 - <rocket::rocket::Rocket as hyper::server::Handler>::handle::h90337c6a29041c8a
   8:   0x5801c3 - <hyper::server::Worker<H>>::handle_connection::h20e08e2c2f0b24cd
   9:   0x558223 - hyper::server::listener::spawn_with::{{closure}}::hc8bf134e303c9e0c
  10:   0x557f97 - std::sys_common::backtrace::__rust_begin_short_backtrace::ha682d6d382a1107b
  11:   0x55aa9f - <F as alloc::boxed::FnBox<A>>::call_box::h1552b33ac6668997
  12:   0x64aa13 - <alloc::boxed::Box<alloc::boxed::FnBox<A, Output$u3d$R$GT$$u20$$u2b$$u20$$u27$a$GT$$u20$as$u20$core..ops..function..FnOnce$LT$A$GT$$GT$::call_once::h4a163f038fb055cf
Cause #1: No such file or directory (os error 2)
```