### PR TITLE
Report local hostname

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ rust-embed = "3.0.0"
 toml = "0.4"
 failure = "0.1.1"
 failure_derive = "0.1.1"
+hostname = "0.1.5"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/hostname.rs
+++ b/src/hostname.rs
@@ -1,0 +1,31 @@
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2018 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  API
+*  Local hostname
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+extern crate hostname;
+
+use util;
+
+/// Get local host name
+#[get("/hostname")]
+pub fn hostname() -> util::Reply {
+    match hostname::get_hostname() {
+        None => {
+            return util::reply_data(json!({
+                "hostname": ""
+            }));
+        }
+        Some(h) => {
+            return util::reply_data(json!({
+                "hostname": h
+            }));
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod setup;
 mod config;
 mod setup_vars;
 mod version;
+mod hostname;
 
 #[cfg(test)]
 mod testing;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -24,6 +24,7 @@ use toml;
 use util::{Error, ErrorKind};
 use web;
 use version;
+use hostname;
 
 const CONFIG_LOCATION: &'static str = "/etc/pihole/API.toml";
 
@@ -136,7 +137,8 @@ fn setup<'a>(
             dns::add_regexlist,
             dns::delete_whitelist,
             dns::delete_blacklist,
-            dns::delete_regexlist
+            dns::delete_regexlist,
+            hostname::hostname
         ])
         // Add custom error handlers
         .catch(errors![not_found, unauthorized])


### PR DESCRIPTION
Gets the hostname of the system pihole is running on.

Intended use :  web interface Settings:Network Information (all other information in that box is obtained from setupVars.conf)