### PR TITLE
Handle long ints from FTL

### DIFF
--- a/src/ftl.rs
+++ b/src/ftl.rs
@@ -125,10 +125,24 @@ impl<'test> FtlConnection<'test> {
         )
     }
 
+    /// Read in a u64 (unsigned longint) value
+    pub fn read_u64(&mut self) -> Result<u64, Error> {
+        FtlConnection::handle_eom_value(
+            decode::read_u64(&mut self.0)
+        )
+    }
+
     /// Read in an i32 (signed int) value
     pub fn read_i32(&mut self) -> Result<i32, Error> {
         FtlConnection::handle_eom_value(
             decode::read_i32(&mut self.0)
+        )
+    }
+
+    /// Read in an i64 (signed longint) value
+    pub fn read_i64(&mut self) -> Result<i64, Error> {
+        FtlConnection::handle_eom_value(
+            decode::read_i64(&mut self.0)
         )
     }
 

--- a/src/ftl.rs
+++ b/src/ftl.rs
@@ -125,7 +125,8 @@ impl<'test> FtlConnection<'test> {
         )
     }
 
-    /// Read in a u64 (unsigned longint) value
+    /// Read in a u64 (unsigned long int) value
+    #[allow(unused)]
     pub fn read_u64(&mut self) -> Result<u64, Error> {
         FtlConnection::handle_eom_value(
             decode::read_u64(&mut self.0)
@@ -139,7 +140,8 @@ impl<'test> FtlConnection<'test> {
         )
     }
 
-    /// Read in an i64 (signed longint) value
+    /// Read in an i64 (signed long int) value
+    #[allow(unused)]
     pub fn read_i64(&mut self) -> Result<i64, Error> {
         FtlConnection::handle_eom_value(
             decode::read_i64(&mut self.0)


### PR DESCRIPTION
FTL reports some information using longints (for example: memory usage, db stats).

Has been tested against these, returns are consistent with telnet interface.

![2018-06-23_21 34 24](https://user-images.githubusercontent.com/35944068/41809230-6b27ef8a-772d-11e8-9bec-657211c15af6.png)




