### PR TITLE
 New value type for IPv4 address, with optional port 

### DIFF
--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -212,7 +212,7 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::InstallWebInterface => ValueType::Boolean,
             SetupVarsEntry::Ipv4Address => ValueType::Ipv4Mask,
             SetupVarsEntry::Ipv6Address => ValueType::Ipv6,
-            SetupVarsEntry::PiholeDns(_) => ValueType::Ipv4,
+            SetupVarsEntry::PiholeDns(_) => ValueType::Ipv4optPort,
             SetupVarsEntry::PiholeDomain => ValueType::Domain,
             SetupVarsEntry::PiholeInterface => ValueType::Interface,
             SetupVarsEntry::QueryLogging => ValueType::Boolean,

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -212,7 +212,7 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::InstallWebInterface => ValueType::Boolean,
             SetupVarsEntry::Ipv4Address => ValueType::Ipv4Mask,
             SetupVarsEntry::Ipv6Address => ValueType::Ipv6,
-            SetupVarsEntry::PiholeDns(_) => ValueType::Ipv4optPort,
+            SetupVarsEntry::PiholeDns(_) => ValueType::IPv4OptionalPort,
             SetupVarsEntry::PiholeDomain => ValueType::Domain,
             SetupVarsEntry::PiholeInterface => ValueType::Interface,
             SetupVarsEntry::QueryLogging => ValueType::Boolean,

--- a/src/settings/value_type.rs
+++ b/src/settings/value_type.rs
@@ -25,7 +25,7 @@ pub enum ValueType {
     Integer,
     Interface,
     Ipv4,
-    Ipv4optPort,
+    IPv4OptionalPort,
     Ipv4Mask,
     Ipv6,
     Path,
@@ -96,22 +96,22 @@ impl ValueType {
                 // Test if valid address falls within permitted ranges
                 value.is_empty() || is_ipv4_valid(value)
             }
-            ValueType::Ipv4optPort => {
+            ValueType::IPv4OptionalPort => {
                 // Valid, in allowable range, with optional port
                 // (4 octets, with port from 0 to 65535, colon delimited), or null
                 if value.is_empty() || is_ipv4_valid(value) {
-                    // check for valid ipv4 (without port)
                     return true;
                 }
                 if !value.contains(":") {
                     return false;
                 }
-
                 // check if port is specified
                 let (ip, portnumber) = value.split_at(value.rfind(":").unwrap_or_default());
-                let port = portnumber.parse::<usize>().unwrap_or_default();
-
-                is_ipv4_valid(ip) && port <= 65535
+                if let Some(port) = portnumber.replace(":", "").parse::<usize>().ok() {
+                    is_ipv4_valid(ip) && port <= 65535
+                } else {
+                    false
+                }
             }
             ValueType::Ipv4Mask => {
                 // Valid, in allowable range, and with mask
@@ -213,8 +213,8 @@ mod tests {
             (ValueType::Integer, "8675309", true),
             (ValueType::Interface, &available_interface, true),
             (ValueType::Ipv4, "192.168.2.9", true),
-            (ValueType::Ipv4optPort, "192.168.4.5:80", true),
-            (ValueType::Ipv4optPort, "192.168.3.3", true),
+            (ValueType::IPv4OptionalPort, "192.168.4.5:80", true),
+            (ValueType::IPv4OptionalPort, "192.168.3.3", true),
             (ValueType::Ipv4Mask, "192.168.0.3/24", true),
             (
                 ValueType::Ipv6,
@@ -249,13 +249,18 @@ mod tests {
                 false
             ),
             (ValueType::Decimal, "3/4", false),
+            (ValueType::Decimal, "3.14.15.26", false),
             (ValueType::Domain, "D0#A!N", false),
             (ValueType::Filename, "c3p0/", false),
             (ValueType::Integer, "9.9", false),
+            (ValueType::Integer, "10m3", false),
             (ValueType::Interface, "/dev/net/ev9d9", false),
             (ValueType::Ipv4, "192.168.0.3/24", false),
-            (ValueType::Ipv4optPort, "192.168.4.5 port 1000", false),
+            (ValueType::Ipv4, "192.168.0.2:53", false),
+            (ValueType::IPv4OptionalPort, "192.168.4.5 port 1000", false),
+            (ValueType::IPv4OptionalPort, "192.168.6.8:arst", false),
             (ValueType::Ipv4Mask, "192.168.2.9", false),
+            (ValueType::Ipv4Mask, "192.168.1.1/qwfp", false),
             (ValueType::Ipv6, "192.168.0.3", false),
             (ValueType::Path, "~/tmp/directory/file.ext", false),
             (ValueType::PortNumber, "65536", false),

--- a/src/settings/value_type.rs
+++ b/src/settings/value_type.rs
@@ -98,8 +98,8 @@ impl ValueType {
             }
             ValueType::Ipv4optPort => {
                 // Valid, in allowable range, with optional port
-                // (4 octets, with port from 0 to 65535, colon delimited)
-                if is_ipv4_valid(value) {
+                // (4 octets, with port from 0 to 65535, colon delimited), or null
+                if value.is_empty() || is_ipv4_valid(value) {
                     // check for valid ipv4 (without port)
                     return true;
                 }

--- a/src/settings/value_type.rs
+++ b/src/settings/value_type.rs
@@ -100,7 +100,7 @@ impl ValueType {
                 // Valid, in allowable range, with optional port
                 // (4 octets, with port from 0 to 65535, colon delimited)
                 if is_ipv4_valid(value) {
-                // check for valid ipv4 (without port)
+                    // check for valid ipv4 (without port)
                     return true;
                 }
                 if !value.contains(":") {
@@ -111,7 +111,7 @@ impl ValueType {
                 let (ip, portnumber) = value.split_at(value.rfind(":").unwrap_or_default());
                 let port = portnumber.parse::<usize>().unwrap_or_default();
 
-                is_ipv4_valid(ip) && port <= 65535 
+                is_ipv4_valid(ip) && port <= 65535
             }
             ValueType::Ipv4Mask => {
                 // Valid, in allowable range, and with mask


### PR DESCRIPTION
IPv4optPort - allowable values : null, ipv4 (4 octets, period delimited), ipv4 (4 octets, period delimited) with port (comma delimited)

SetupVarsEntry::PiholeDns(_) changed to IPv4optPort.

Signed-off-by: Rob Gill <rrobgill@protonmail.com>