### PR TITLE
Validate config on startup

### DIFF
--- a/src/env/config.rs
+++ b/src/env/config.rs
@@ -210,3 +210,62 @@ fn default_port() -> usize {
 fn default_log_level() -> String {
     "critical".to_owned()
 }
+
+#[cfg(test)]
+mod test {
+    use super::{Config, Files, General};
+
+    #[test]
+    fn valid_config() {
+        let config = Config::default();
+        assert!(config.is_valid());
+    }
+
+    #[test]
+    fn valid_files() {
+        let files = Files::default();
+        assert!(files.is_valid());
+    }
+
+    #[test]
+    fn valid_general() {
+        let general = General::default();
+        assert!(general.is_valid());
+    }
+
+    #[test]
+    fn invalid_file() {
+        let files = Files {
+            setup_vars: "!asd?f".to_owned(),
+            ..Files::default()
+        };
+        assert!(!files.is_valid());
+    }
+
+    #[test]
+    fn invalid_general_address() {
+        let general = General {
+            address: "hello_world".to_owned(),
+            ..General::default()
+        };
+        assert!(!general.is_valid());
+    }
+
+    #[test]
+    fn invalid_general_port() {
+        let general = General {
+            port: 65536,
+            ..General::default()
+        };
+        assert!(!general.is_valid());
+    }
+
+    #[test]
+    fn invalid_general_log_level() {
+        let general = General {
+            log_level: "hello_world".to_owned(),
+            ..General::default()
+        };
+        assert!(!general.is_valid());
+    }
+}

--- a/src/env/config.rs
+++ b/src/env/config.rs
@@ -10,9 +10,13 @@
 
 use env::PiholeFile;
 use failure::Fail;
+use failure::ResultExt;
 use rocket::config::LoggingLevel;
 use std::fs::File;
 use std::io::{self, prelude::*};
+use std::net::Ipv4Addr;
+use std::path::Path;
+use std::str::FromStr;
 use toml;
 use util::{Error, ErrorKind};
 
@@ -46,7 +50,18 @@ impl Config {
         file.read_to_string(&mut buffer)
             .map_err(|e| e.context(ErrorKind::FileRead(config_location.to_owned())))?;
 
-        toml::from_str(&buffer).map_err(|e| e.context(ErrorKind::ConfigParsingError).into())
+        let config = toml::from_str::<Config>(&buffer).context(ErrorKind::ConfigParsingError)?;
+
+        if config.is_valid() {
+            Ok(config)
+        } else {
+            Err(Error::from(ErrorKind::ConfigParsingError))
+        }
+    }
+
+    /// Check if the config settings are valid
+    pub fn is_valid(&self) -> bool {
+        self.general.is_valid() && self.file_locations.is_valid()
     }
 
     /// Get the configured location of a file
@@ -76,7 +91,7 @@ impl Config {
             "critical" => LoggingLevel::Critical,
             "normal" => LoggingLevel::Normal,
             "debug" => LoggingLevel::Debug,
-            // TODO: validate config on startup
+            // Should never happen, since config is validated on startup
             _ => LoggingLevel::Critical
         }
     }
@@ -119,6 +134,22 @@ impl Default for Files {
     }
 }
 
+impl Files {
+    fn is_valid(&self) -> bool {
+        [
+            &self.dnsmasq_config,
+            &self.whitelist,
+            &self.blacklist,
+            &self.regexlist,
+            &self.setup_vars,
+            &self.ftl_config,
+            &self.local_versions,
+            &self.local_branches
+        ].into_iter()
+            .all(|file| Path::new(file).is_absolute())
+    }
+}
+
 /// Create an `fn() -> String` default function for deserialization
 macro_rules! default {
     ($fn_name:ident, $variant:ident) => {
@@ -155,6 +186,16 @@ impl Default for General {
             port: default_port(),
             log_level: default_log_level()
         }
+    }
+}
+
+impl General {
+    fn is_valid(&self) -> bool {
+        Ipv4Addr::from_str(&self.address).is_ok() && self.port <= 65535
+            && match self.log_level.as_str() {
+                "debug" | "normal" | "critical" => true,
+                _ => false
+            }
     }
 }
 


### PR DESCRIPTION
The configuration now gets validated at startup (and there are tests for this).
The general configuration checks the address, port, and log level. The files get checked to make sure they are absolute.