### PR TITLE
Clean up apt cache in Dockerfile

### DIFF
--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:stretch
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates git \
         gcc libc-dev gcc-aarch64-linux-gnu libc-dev-arm64-cross && \
+    rm -rf /var/lib/apt/lists/* && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-06-20 && \
     export PATH="/root/.cargo/bin:$PATH" && \
     rustup target add aarch64-unknown-linux-gnu

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:stretch
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates git \
         gcc libc-dev gcc-arm-linux-gnueabi libc-dev-armel-cross && \
+    rm -rf /var/lib/apt/lists/* && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-06-20 && \
     export PATH="/root/.cargo/bin:$PATH" && \
     rustup target add arm-unknown-linux-gnueabi

--- a/docker/armhf/Dockerfile
+++ b/docker/armhf/Dockerfile
@@ -4,6 +4,7 @@ FROM debian:stretch
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates git \
         gcc libc-dev gcc-arm-linux-gnueabihf libc6-dev-armhf-cross && \
+    rm -rf /var/lib/apt/lists/* && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-06-20 && \
     export PATH="/root/.cargo/bin:$PATH" && \
     rustup target add arm-unknown-linux-gnueabihf

--- a/docker/x86_32/Dockerfile
+++ b/docker/x86_32/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:stretch
 # Install Rust
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates gcc gcc-multilib git && \
+    rm -rf /var/lib/apt/lists/* && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-06-20 && \
     export PATH="/root/.cargo/bin:$PATH" && \
     rustup target add i686-unknown-linux-gnu

--- a/docker/x86_64-musl/Dockerfile
+++ b/docker/x86_64-musl/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:stretch
 # Install Rust
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates libc-dev musl-tools git && \
+    rm -rf /var/lib/apt/lists/* && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-06-20 && \
     export PATH="/root/.cargo/bin:$PATH" && \
     rustup target add x86_64-unknown-linux-musl

--- a/docker/x86_64/Dockerfile
+++ b/docker/x86_64/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:stretch
 # Install Rust
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates gcc libc-dev git && \
+    rm -rf /var/lib/apt/lists/* && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2018-06-20 && \
     export PATH="/root/.cargo/bin:$PATH"
 


### PR DESCRIPTION
Clean the apt cache to make the image smaller and smaller.

Ref: https://docs.docker.com/develop/develop-images/dockerfile_best-practices