### PR TITLE
Add a nicer looking alias for reading a setting as a boolean

### DIFF
--- a/src/routes/dns/status.rs
+++ b/src/routes/dns/status.rs
@@ -16,7 +16,7 @@ use util::{reply_data, Reply};
 /// Get the DNS blocking status
 #[get("/dns/status")]
 pub fn status(env: State<Env>) -> Reply {
-    let status = if SetupVarsEntry::BlockingEnabled.read_as(&env)? {
+    let status = if SetupVarsEntry::BlockingEnabled.is_true(&env)? {
         "enabled"
     } else {
         "disabled"

--- a/src/routes/settings/dns.rs
+++ b/src/routes/settings/dns.rs
@@ -90,13 +90,13 @@ pub fn get_dns(env: State<Env>, _auth: User) -> Reply {
     let dns_settings = DnsSettings {
         upstream_dns: get_upstream_dns(&env)?,
         options: DnsOptions {
-            fqdn_required: SetupVarsEntry::DnsFqdnRequired.read_as(&env)?,
-            bogus_priv: SetupVarsEntry::DnsBogusPriv.read_as(&env)?,
-            dnssec: SetupVarsEntry::Dnssec.read_as(&env)?,
+            fqdn_required: SetupVarsEntry::DnsFqdnRequired.is_true(&env)?,
+            bogus_priv: SetupVarsEntry::DnsBogusPriv.is_true(&env)?,
+            dnssec: SetupVarsEntry::Dnssec.is_true(&env)?,
             listening_type: SetupVarsEntry::DnsmasqListening.read(&env)?
         },
         conditional_forwarding: DnsConditionalForwarding {
-            enabled: SetupVarsEntry::ConditionalForwarding.read_as(&env)?,
+            enabled: SetupVarsEntry::ConditionalForwarding.is_true(&env)?,
             router_ip: SetupVarsEntry::ConditionalForwardingIp.read(&env)?,
             domain: SetupVarsEntry::ConditionalForwardingDomain.read(&env)?
         }

--- a/src/routes/settings/get_ftl.rs
+++ b/src/routes/settings/get_ftl.rs
@@ -31,7 +31,7 @@ pub fn get_ftl(env: State<Env>, _auth: User) -> Reply {
     let privacy_level: i32 = FtlConfEntry::PrivacyLevel.read_as(&env)?;
     let ignore_local_host = FtlConfEntry::IgnoreLocalHost.read(&env)?;
     let blocking_mode = FtlConfEntry::BlockingMode.read(&env)?;
-    let regex_debug_mode: bool = FtlConfEntry::RegexDebugMode.read_as(&env)?;
+    let regex_debug_mode = FtlConfEntry::RegexDebugMode.is_true(&env)?;
 
     reply_data(json!({
         "socket_listening": socket_listening,

--- a/src/routes/stats/summary.rs
+++ b/src/routes/stats/summary.rs
@@ -53,7 +53,7 @@ pub fn get_summary(ftl_memory: State<FtlMemory>, env: State<Env>) -> Reply {
         }
     };
 
-    let status = if SetupVarsEntry::BlockingEnabled.read_as(&env)? {
+    let status = if SetupVarsEntry::BlockingEnabled.is_true(&env)? {
         "enabled"
     } else {
         "disabled"

--- a/src/settings/dnsmasq.rs
+++ b/src/settings/dnsmasq.rs
@@ -95,7 +95,7 @@ fn write_lists(config_file: &mut BufWriter<File>) -> Result<(), Error> {
 
 /// Write various DNS settings
 fn write_dns_options(config_file: &mut BufWriter<File>, env: &Env) -> Result<(), Error> {
-    if SetupVarsEntry::QueryLogging.read_as(env)? {
+    if SetupVarsEntry::QueryLogging.is_true(env)? {
         config_file
             .write_all(
                 b"log-queries\n\
@@ -105,19 +105,19 @@ fn write_dns_options(config_file: &mut BufWriter<File>, env: &Env) -> Result<(),
             .context(ErrorKind::DnsmasqConfigWrite)?;
     }
 
-    if SetupVarsEntry::DnsFqdnRequired.read_as(env)? {
+    if SetupVarsEntry::DnsFqdnRequired.is_true(env)? {
         config_file
             .write_all(b"domain-needed\n")
             .context(ErrorKind::DnsmasqConfigWrite)?;
     }
 
-    if SetupVarsEntry::DnsBogusPriv.read_as(env)? {
+    if SetupVarsEntry::DnsBogusPriv.is_true(env)? {
         config_file
             .write_all(b"bogus-priv\n")
             .context(ErrorKind::DnsmasqConfigWrite)?;
     }
 
-    if SetupVarsEntry::Dnssec.read_as(env)? {
+    if SetupVarsEntry::Dnssec.is_true(env)? {
         config_file.write_all(
             b"dnssec\n\
             trust-anchor=.,19036,8,2,49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n\
@@ -147,7 +147,7 @@ fn write_dns_options(config_file: &mut BufWriter<File>, env: &Env) -> Result<(),
         }
     }
 
-    if SetupVarsEntry::ConditionalForwarding.read_as(env)? {
+    if SetupVarsEntry::ConditionalForwarding.is_true(env)? {
         let ip = SetupVarsEntry::ConditionalForwardingIp.read(env)?;
 
         writeln!(

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -38,6 +38,11 @@ pub trait ConfigEntry {
         value.is_empty() || self.value_type().is_valid(value)
     }
 
+    /// Try to read the value and parse into a boolean.
+    fn is_true(&self, env: &Env) -> Result<bool, Error> {
+        self.read_as::<bool>(env)
+    }
+
     /// Try to read the value and parse into `T`.
     /// If it is unable to be parsed into `T`, an error is returned.
     fn read_as<T: FromStr>(&self, env: &Env) -> Result<T, Error>


### PR DESCRIPTION
`read_as` in an if statement could be confusing, so this alias will cover the common use case of reading a setting as a boolean.