### PR TITLE
Return extra information with errors

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -123,6 +123,7 @@ pub fn logout(user: User, cookies: Cookies) -> Reply {
 #[cfg(test)]
 mod test {
     use rocket::http::{Header, Status};
+    use rocket_contrib::Value;
     use testing::TestBuilder;
 
     #[test]
@@ -145,7 +146,8 @@ mod test {
             .expect_json(json!({
                 "error": {
                     "key": "unauthorized",
-                    "message": "Unauthorized"
+                    "message": "Unauthorized",
+                    "data": Value::Null
                 }
             }))
             .test()
@@ -164,7 +166,8 @@ mod test {
             .expect_json(json!({
                 "error": {
                     "key": "unauthorized",
-                    "message": "Unauthorized"
+                    "message": "Unauthorized",
+                    "data": Value::Null
                 }
             }))
             .test();


### PR DESCRIPTION
This will aid in parsing and translating the errors on the web
interface. The format of an error is now:

```
{
  "error": {
    "key": string,
    "message": string,
    "data": object or null
  }
}
```