### PR TITLE
Simplify FtlClient::get_name

### DIFF
--- a/src/ftl/memory_model/client.rs
+++ b/src/ftl/memory_model/client.rs
@@ -54,11 +54,7 @@ impl FtlClient {
     /// doesn't exist
     pub fn get_name<'a>(&self, strings: &'a FtlStrings) -> Option<&'a str> {
         if !self.is_name_unknown && self.name_str_id != 0 {
-            Some(
-                strings
-                    .get_str(self.name_str_id as usize)
-                    .unwrap_or_default()
-            )
+            strings.get_str(self.name_str_id as usize)
         } else {
             None
         }


### PR DESCRIPTION
Previously, if the string was not found in memory when it was supposed to exist, an empty string would be returned instead of `None`.