### PR TITLE
Prevent the scheduler from panicking if blocking is already enabled

### DIFF
--- a/src/routes/dns/status.rs
+++ b/src/routes/dns/status.rs
@@ -116,7 +116,9 @@ fn disable(env: &Env, time: Option<usize>, scheduler: Option<&Scheduler>) -> Res
             scheduler
                 .unwrap()
                 .after_duration(Duration::from_secs(time as u64), move || {
-                    enable(&env_copy).unwrap()
+                    // Ignore the result of enabling, so that if it's an error
+                    // the thread does not panic
+                    let _ = enable(&env_copy);
                 });
         }
     }


### PR DESCRIPTION
The scenario:
1. User disables blocking for 10 seconds
2. User immediately re-enables blocking
3. When the 10 seconds are up the scheduler tries to re-enable blocking.
    When this happens, it used to unwrap the Result, and would panic.
    Now the scheduler thread is unusable.

The result of enabling is now ignored so that the scheduler thread doesn't experience a panic.