### PR TITLE
Add web settings endpoint

### DIFF
--- a/src/routes/settings/mod.rs
+++ b/src/routes/settings/mod.rs
@@ -14,5 +14,6 @@ mod dns;
 mod get_ftl;
 mod get_ftldb;
 mod get_network;
+mod web;
 
-pub use self::{common::*, dhcp::*, dns::*, get_ftl::*, get_ftldb::*, get_network::*};
+pub use self::{common::*, dhcp::*, dns::*, get_ftl::*, get_ftldb::*, get_network::*, web::*};

--- a/src/routes/settings/web.rs
+++ b/src/routes/settings/web.rs
@@ -1,0 +1,54 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2018 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// Web Interface Settings Endpoints
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use crate::{
+    env::Env,
+    routes::auth::User,
+    settings::{ConfigEntry, SetupVarsEntry},
+    util::{reply_data, reply_success, Error, ErrorKind, Reply}
+};
+use rocket::State;
+use rocket_contrib::json::Json;
+
+/// Get web interface settings
+#[get("/settings/web")]
+pub fn get_web(_auth: User, env: State<Env>) -> Reply {
+    let settings = WebSettings {
+        layout: SetupVarsEntry::WebLayout.read(&env)?
+    };
+
+    reply_data(settings)
+}
+
+/// Update web interface settings
+#[put("/settings/web", data = "<settings>")]
+pub fn put_web(_auth: User, env: State<Env>, settings: Json<WebSettings>) -> Reply {
+    let settings = settings.into_inner();
+
+    if !settings.is_valid() {
+        return Err(Error::from(ErrorKind::InvalidSettingValue));
+    }
+
+    SetupVarsEntry::WebLayout.write(&settings.layout, &env)?;
+
+    reply_success()
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WebSettings {
+    layout: String
+}
+
+impl WebSettings {
+    /// Check if all the web settings are valid
+    fn is_valid(&self) -> bool {
+        SetupVarsEntry::WebLayout.is_valid(&self.layout)
+    }
+}

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -175,7 +175,8 @@ pub enum SetupVarsEntry {
     PiholeDomain,
     PiholeInterface,
     QueryLogging,
-    WebPassword
+    WebPassword,
+    WebLayout
 }
 
 impl ConfigEntry for SetupVarsEntry {
@@ -184,7 +185,7 @@ impl ConfigEntry for SetupVarsEntry {
     }
 
     fn key(&self) -> Cow<str> {
-        match *self {
+        match self {
             SetupVarsEntry::ApiExcludeClients => Cow::Borrowed("API_EXCLUDE_CLIENTS"),
             SetupVarsEntry::ApiExcludeDomains => Cow::Borrowed("API_EXCLUDE_DOMAINS"),
             SetupVarsEntry::ApiQueryLogShow => Cow::Borrowed("API_QUERY_LOG_SHOW"),
@@ -214,12 +215,13 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::PiholeDomain => Cow::Borrowed("PIHOLE_DOMAIN"),
             SetupVarsEntry::PiholeInterface => Cow::Borrowed("PIHOLE_INTERFACE"),
             SetupVarsEntry::QueryLogging => Cow::Borrowed("QUERY_LOGGING"),
-            SetupVarsEntry::WebPassword => Cow::Borrowed("WEBPASSWORD")
+            SetupVarsEntry::WebPassword => Cow::Borrowed("WEBPASSWORD"),
+            SetupVarsEntry::WebLayout => Cow::Borrowed("WEBUIBOXEDLAYOUT")
         }
     }
 
     fn value_type(&self) -> ValueType {
-        match *self {
+        match self {
             SetupVarsEntry::ApiExcludeClients => {
                 ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4, ValueType::Ipv6])
             }
@@ -249,12 +251,13 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::PiholeDomain => ValueType::Hostname,
             SetupVarsEntry::PiholeInterface => ValueType::Interface,
             SetupVarsEntry::QueryLogging => ValueType::Boolean,
-            SetupVarsEntry::WebPassword => ValueType::WebPassword
+            SetupVarsEntry::WebPassword => ValueType::WebPassword,
+            SetupVarsEntry::WebLayout => ValueType::String(&["boxed", "traditional"])
         }
     }
 
     fn get_default(&self) -> &str {
-        match *self {
+        match self {
             SetupVarsEntry::ApiExcludeClients => "",
             SetupVarsEntry::ApiExcludeDomains => "",
             SetupVarsEntry::ApiQueryLogShow => "all",
@@ -280,7 +283,8 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::PiholeDomain => "",
             SetupVarsEntry::PiholeInterface => "",
             SetupVarsEntry::QueryLogging => "false",
-            SetupVarsEntry::WebPassword => ""
+            SetupVarsEntry::WebPassword => "",
+            SetupVarsEntry::WebLayout => "boxed"
         }
     }
 }
@@ -344,7 +348,7 @@ impl ConfigEntry for FtlConfEntry {
     }
 
     fn key(&self) -> Cow<str> {
-        Cow::Borrowed(match *self {
+        Cow::Borrowed(match self {
             FtlConfEntry::AaaaQueryAnalysis => "AAAA_QUERY_ANALYSIS",
             FtlConfEntry::BlockingMode => "BLOCKINGMODE",
             FtlConfEntry::DbFile => "DBFILE",
@@ -363,7 +367,7 @@ impl ConfigEntry for FtlConfEntry {
     }
 
     fn value_type(&self) -> ValueType {
-        match *self {
+        match self {
             FtlConfEntry::AaaaQueryAnalysis => ValueType::YesNo,
             FtlConfEntry::BlockingMode => {
                 ValueType::String(&["NULL", "IP-AAAA-NODATA", "IP", "NXDOMAIN"])
@@ -384,7 +388,7 @@ impl ConfigEntry for FtlConfEntry {
     }
 
     fn get_default(&self) -> &str {
-        match *self {
+        match self {
             FtlConfEntry::AaaaQueryAnalysis => "yes",
             FtlConfEntry::BlockingMode => "NULL",
             FtlConfEntry::DbFile => "/etc/pihole/pihole-FTL.db",

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -181,6 +181,8 @@ fn setup(
             settings::put_dns,
             settings::get_ftldb,
             settings::get_ftl,
-            settings::get_network
+            settings::get_network,
+            settings::get_web,
+            settings::put_web
         ])
 }


### PR DESCRIPTION
This endpoint currently supports saving the layout configuration of the web interface.

Required for pi-hole/web#105