### PR TITLE
Add language as a web setting

### DIFF
--- a/src/routes/settings/web.rs
+++ b/src/routes/settings/web.rs
@@ -21,7 +21,8 @@ use rocket_contrib::json::Json;
 #[get("/settings/web")]
 pub fn get_web(_auth: User, env: State<Env>) -> Reply {
     let settings = WebSettings {
-        layout: SetupVarsEntry::WebLayout.read(&env)?
+        layout: SetupVarsEntry::WebLayout.read(&env)?,
+        language: SetupVarsEntry::WebLanguage.read(&env)?
     };
 
     reply_data(settings)
@@ -37,18 +38,21 @@ pub fn put_web(_auth: User, env: State<Env>, settings: Json<WebSettings>) -> Rep
     }
 
     SetupVarsEntry::WebLayout.write(&settings.layout, &env)?;
+    SetupVarsEntry::WebLanguage.write(&settings.language, &env)?;
 
     reply_success()
 }
 
 #[derive(Serialize, Deserialize)]
 pub struct WebSettings {
-    layout: String
+    layout: String,
+    language: String
 }
 
 impl WebSettings {
     /// Check if all the web settings are valid
     fn is_valid(&self) -> bool {
         SetupVarsEntry::WebLayout.is_valid(&self.layout)
+            && SetupVarsEntry::WebLanguage.is_valid(&self.language)
     }
 }

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -176,7 +176,8 @@ pub enum SetupVarsEntry {
     PiholeInterface,
     QueryLogging,
     WebPassword,
-    WebLayout
+    WebLayout,
+    WebLanguage
 }
 
 impl ConfigEntry for SetupVarsEntry {
@@ -216,7 +217,8 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::PiholeInterface => Cow::Borrowed("PIHOLE_INTERFACE"),
             SetupVarsEntry::QueryLogging => Cow::Borrowed("QUERY_LOGGING"),
             SetupVarsEntry::WebPassword => Cow::Borrowed("WEBPASSWORD"),
-            SetupVarsEntry::WebLayout => Cow::Borrowed("WEBUIBOXEDLAYOUT")
+            SetupVarsEntry::WebLayout => Cow::Borrowed("WEBUIBOXEDLAYOUT"),
+            SetupVarsEntry::WebLanguage => Cow::Borrowed("WEB_LANGUAGE")
         }
     }
 
@@ -252,7 +254,8 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::PiholeInterface => ValueType::Interface,
             SetupVarsEntry::QueryLogging => ValueType::Boolean,
             SetupVarsEntry::WebPassword => ValueType::WebPassword,
-            SetupVarsEntry::WebLayout => ValueType::String(&["boxed", "traditional"])
+            SetupVarsEntry::WebLayout => ValueType::String(&["boxed", "traditional"]),
+            SetupVarsEntry::WebLanguage => ValueType::LanguageCode
         }
     }
 
@@ -284,7 +287,8 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::PiholeInterface => "",
             SetupVarsEntry::QueryLogging => "false",
             SetupVarsEntry::WebPassword => "",
-            SetupVarsEntry::WebLayout => "boxed"
+            SetupVarsEntry::WebLayout => "boxed",
+            SetupVarsEntry::WebLanguage => "en"
         }
     }
 }

--- a/src/settings/value_type.rs
+++ b/src/settings/value_type.rs
@@ -39,7 +39,8 @@ pub enum ValueType {
     PortNumber,
     YesNo,
     WebPassword,
-    String(&'static [&'static str])
+    String(&'static [&'static str]),
+    LanguageCode
 }
 
 impl ValueType {
@@ -187,7 +188,10 @@ impl ValueType {
                 // Web password is a valid key, but altering it is disallowed
                 false
             }
-            ValueType::String(strings) => strings.contains(&value)
+            ValueType::String(strings) => strings.contains(&value),
+            ValueType::LanguageCode => Regex::new("^[a-zA-Z]+(-[a-zA-Z]+)*$")
+                .unwrap()
+                .is_match(value)
         }
     }
 }


### PR DESCRIPTION
It is stored in setupVars under `WEB_LANGUAGE` as the language code.
Example: `WEB_LANGUAGE=en`

Required for pi-hole/web#105