### PR TITLE
Implement API_EXCLUDE_*, API_QUERY_LOG_SHOW (for database), and organize DB filters

### DIFF
--- a/src/databases/ftl/mod.rs
+++ b/src/databases/ftl/mod.rs
@@ -8,7 +8,19 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
+#[cfg(test)]
+use diesel::{sqlite::SqliteConnection, Connection};
+
 mod model;
 mod schema;
 
 pub use self::{model::*, schema::*};
+
+#[cfg(test)]
+pub const TEST_FTL_DATABASE_PATH: &str = "test/FTL.db";
+
+/// Connect to the testing database
+#[cfg(test)]
+pub fn connect_to_test_db() -> SqliteConnection {
+    SqliteConnection::establish(TEST_FTL_DATABASE_PATH).unwrap()
+}

--- a/src/databases/mod.rs
+++ b/src/databases/mod.rs
@@ -16,6 +16,9 @@ use crate::{
 use rocket::config::Value;
 use std::collections::HashMap;
 
+#[cfg(test)]
+use crate::databases::ftl::TEST_FTL_DATABASE_PATH;
+
 pub mod ftl;
 
 /// Load the database URLs from the API config into the Rocket config format
@@ -29,16 +32,13 @@ pub fn load_databases(env: &Env) -> Result<HashMap<&str, HashMap<&str, Value>>, 
     Ok(databases)
 }
 
-#[cfg(test)]
-pub const TEST_DATABASE_PATH: &str = "test/FTL.db";
-
 /// Load test database URLs into the Rocket config format
 #[cfg(test)]
 pub fn load_test_databases() -> HashMap<&'static str, HashMap<&'static str, Value>> {
     let mut databases = HashMap::new();
     let mut ftl_database = HashMap::new();
 
-    ftl_database.insert("url", Value::from(TEST_DATABASE_PATH));
+    ftl_database.insert("url", Value::from(TEST_FTL_DATABASE_PATH));
     databases.insert("ftl_database", ftl_database);
 
     databases

--- a/src/ftl/memory_model/mod.rs
+++ b/src/ftl/memory_model/mod.rs
@@ -31,7 +31,7 @@ pub use self::{
     domain::{FtlDomain, FtlRegexMatch},
     lock::FtlLock,
     over_time::FtlOverTime,
-    query::{FtlDnssecType, FtlQuery, FtlQueryReplyType, FtlQueryStatus},
+    query::{FtlDnssecType, FtlQuery, FtlQueryReplyType, FtlQueryStatus, BLOCKED_STATUSES},
     settings::FtlSettings,
     strings::FtlStrings,
     upstream::FtlUpstream

--- a/src/ftl/memory_model/query.rs
+++ b/src/ftl/memory_model/query.rs
@@ -13,7 +13,7 @@ use libc;
 use rocket::{http::RawStr, request::FromFormValue};
 
 /// A list of query statuses which mark a query as blocked
-pub static BLOCKED_STATUSES: [i32; 4] = [
+pub const BLOCKED_STATUSES: [i32; 4] = [
     FtlQueryStatus::Gravity as i32,
     FtlQueryStatus::Wildcard as i32,
     FtlQueryStatus::Blacklist as i32,

--- a/src/ftl/memory_model/query.rs
+++ b/src/ftl/memory_model/query.rs
@@ -12,6 +12,14 @@ use crate::ftl::FtlQueryType;
 use libc;
 use rocket::{http::RawStr, request::FromFormValue};
 
+/// A list of query statuses which mark a query as blocked
+pub static BLOCKED_STATUSES: [i32; 4] = [
+    FtlQueryStatus::Gravity as i32,
+    FtlQueryStatus::Wildcard as i32,
+    FtlQueryStatus::Blacklist as i32,
+    FtlQueryStatus::ExternalBlock as i32
+];
+
 /// The query struct stored in shared memory
 #[repr(C)]
 #[cfg_attr(test, derive(PartialEq, Debug))]
@@ -40,13 +48,7 @@ pub struct FtlQuery {
 impl FtlQuery {
     /// Check if the query was blocked
     pub fn is_blocked(&self) -> bool {
-        match self.status {
-            FtlQueryStatus::Gravity
-            | FtlQueryStatus::Wildcard
-            | FtlQueryStatus::Blacklist
-            | FtlQueryStatus::ExternalBlock => true,
-            _ => false
-        }
+        BLOCKED_STATUSES.contains(&(self.status as i32))
     }
 }
 

--- a/src/routes/stats/common.rs
+++ b/src/routes/stats/common.rs
@@ -14,6 +14,7 @@ use crate::{
     settings::{ConfigEntry, SetupVarsEntry},
     util::Error
 };
+use std::collections::HashSet;
 
 /// Remove clients from the `clients` vector if they show up in
 /// [`SetupVarsEntry::ApiExcludeClients`].
@@ -26,7 +27,7 @@ pub fn remove_excluded_clients(
     strings: &FtlStrings
 ) -> Result<(), Error> {
     let excluded_clients = SetupVarsEntry::ApiExcludeClients.read(env)?.to_lowercase();
-    let excluded_clients: Vec<&str> = excluded_clients
+    let excluded_clients: HashSet<&str> = excluded_clients
         .split(',')
         .filter(|s| !s.is_empty())
         .collect();
@@ -55,7 +56,7 @@ pub fn remove_excluded_domains(
     strings: &FtlStrings
 ) -> Result<(), Error> {
     let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
-    let excluded_domains: Vec<&str> = excluded_domains
+    let excluded_domains: HashSet<&str> = excluded_domains
         .split(',')
         .filter(|s| !s.is_empty())
         .collect();

--- a/src/routes/stats/history/database.rs
+++ b/src/routes/stats/history/database.rs
@@ -63,6 +63,7 @@ pub fn load_queries_from_database(
     let db_query = filter_blocked_db(db_query, params);
     let db_query = filter_excluded_domains_db(db_query, env)?;
     let db_query = filter_excluded_clients_db(db_query, env)?;
+    let db_query = filter_setup_vars_setting_db(db_query, env)?;
 
     // Execute the query and load the results
     let mut results: Vec<FtlDbQuery> = execute_query(db, db_query)?;

--- a/src/routes/stats/history/database.rs
+++ b/src/routes/stats/history/database.rs
@@ -9,12 +9,15 @@
 // Please see LICENSE file for your rights under this license.
 
 use crate::{
-    databases::ftl::FtlDbQuery,
-    ftl::FtlQueryStatus,
-    routes::stats::history::endpoints::{HistoryCursor, HistoryParams},
+    databases::ftl::{queries, FtlDbQuery},
+    routes::stats::history::{
+        endpoints::{HistoryCursor, HistoryParams},
+        filters::*,
+        skip_to_cursor::skip_to_cursor_db
+    },
     util::{Error, ErrorKind}
 };
-use diesel::{prelude::*, query_builder::BoxedSelectStatement};
+use diesel::{prelude::*, sqlite::Sqlite};
 use failure::ResultExt;
 
 /// Load queries from the database according to the parameters. A cursor is
@@ -36,7 +39,7 @@ pub fn load_queries_from_database(
     use crate::databases::ftl::queries::dsl::*;
 
     // Start creating the database query
-    let mut db_query: BoxedSelectStatement<_, _, _> = queries
+    let db_query = queries
         // The query must be boxed, because we are dynamically building it
         .into_boxed()
         // Take up to the limit, plus one to build the cursor
@@ -45,61 +48,20 @@ pub fn load_queries_from_database(
         .order(id.desc());
 
     // If a start ID is given, ignore any queries before it
-    if let Some(start_id) = start_id {
-        db_query = db_query.filter(id.le(start_id as i32));
-    }
+    let db_query = skip_to_cursor_db(db_query, start_id);
 
     // Apply filters
-
-    if let Some(from) = params.from {
-        db_query = db_query.filter(timestamp.ge(from as i32));
-    }
-
-    if let Some(until) = params.until {
-        db_query = db_query.filter(timestamp.le(until as i32));
-    }
-
-    if let Some(ref search_domain) = params.domain {
-        db_query = db_query.filter(domain.like(format!("%{}%", search_domain)));
-    }
-
-    if let Some(ref search_client) = params.client {
-        db_query = db_query.filter(client.like(format!("%{}%", search_client)));
-    }
-
-    if let Some(ref search_upstream) = params.upstream {
-        db_query = db_query.filter(upstream.like(format!("%{}%", search_upstream)));
-    }
-
-    if let Some(search_query_type) = params.query_type {
-        db_query = db_query.filter(query_type.eq(search_query_type as i32));
-    }
-
-    if let Some(search_status) = params.status {
-        db_query = db_query.filter(status.eq(search_status as i32));
-    }
-
-    // A list of query statuses which mark a query as blocked
-    let blocked_statuses = [
-        FtlQueryStatus::Gravity as i32,
-        FtlQueryStatus::Wildcard as i32,
-        FtlQueryStatus::Blacklist as i32,
-        FtlQueryStatus::ExternalBlock as i32
-    ];
-
-    if let Some(blocked) = params.blocked {
-        db_query = if blocked {
-            db_query.filter(status.eq_any(&blocked_statuses))
-        } else {
-            db_query.filter(status.ne_all(&blocked_statuses))
-        };
-    }
+    let db_query = filter_time_from_db(db_query, params);
+    let db_query = filter_time_until_db(db_query, params);
+    let db_query = filter_domain_db(db_query, params);
+    let db_query = filter_client_db(db_query, params);
+    let db_query = filter_upstream_db(db_query, params);
+    let db_query = filter_query_type_db(db_query, params);
+    let db_query = filter_status_db(db_query, params);
+    let db_query = filter_blocked_db(db_query, params);
 
     // Execute the query and load the results
-    let mut results: Vec<FtlDbQuery> = db_query
-        .load(db as &SqliteConnection)
-        .context(ErrorKind::FtlDatabase)
-        .map_err(Error::from)?;
+    let mut results: Vec<FtlDbQuery> = execute_query(db, db_query)?;
 
     // If more queries could be loaded beyond the given limit (if we loaded
     // limit + 1 queries), then set the cursor to use the limit + 1 query's ID.
@@ -119,45 +81,25 @@ pub fn load_queries_from_database(
     Ok((results, cursor))
 }
 
+/// Execute a database query for DNS queries on an FTL database.
+/// The database could be real, or it could be a test database.
+pub fn execute_query(
+    db: &SqliteConnection,
+    db_query: queries::BoxedQuery<Sqlite>
+) -> Result<Vec<FtlDbQuery>, Error> {
+    db_query
+        .load(db as &SqliteConnection)
+        .context(ErrorKind::FtlDatabase)
+        .map_err(Error::from)
+}
+
 #[cfg(test)]
 mod test {
     use super::load_queries_from_database;
     use crate::{
-        databases::{ftl::FtlDbQuery, TEST_DATABASE_PATH},
-        ftl::{FtlQueryStatus, FtlQueryType},
+        databases::ftl::connect_to_test_db,
         routes::stats::history::endpoints::{HistoryCursor, HistoryParams}
     };
-    use diesel::prelude::*;
-
-    /// Connect to the testing database
-    fn connect_to_test_db() -> SqliteConnection {
-        SqliteConnection::establish(TEST_DATABASE_PATH).unwrap()
-    }
-
-    /// Search starts from the start_id
-    #[test]
-    fn start_id() {
-        let expected_queries = vec![FtlDbQuery {
-            id: Some(1),
-            timestamp: 0,
-            query_type: 6,
-            status: 3,
-            domain: "1.1.1.10.in-addr.arpa".to_owned(),
-            client: "127.0.0.1".to_owned(),
-            upstream: None
-        }];
-
-        let (queries, cursor) = load_queries_from_database(
-            &connect_to_test_db(),
-            Some(1),
-            &HistoryParams::default(),
-            100
-        )
-        .unwrap();
-
-        assert_eq!(queries, expected_queries);
-        assert_eq!(cursor, None);
-    }
 
     /// Queries are ordered by id, descending
     #[test]
@@ -193,138 +135,5 @@ mod test {
 
         assert_eq!(queries.len(), 2);
         assert_eq!(cursor, expected_cursor);
-    }
-
-    /// Only queries newer than `from` are returned
-    #[test]
-    fn from() {
-        let from = 177_179;
-        let params = HistoryParams {
-            from: Some(from),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert!(queries[0].timestamp >= from as i32);
-    }
-
-    /// Only queries older than `until` are returned
-    #[test]
-    fn until() {
-        let until = 1;
-        let params = HistoryParams {
-            until: Some(until),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert!(queries[0].timestamp <= until as i32);
-    }
-
-    /// Only queries with domains similar to the input are returned.
-    #[test]
-    fn domain() {
-        let params = HistoryParams {
-            domain: Some("goog".to_owned()),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert_eq!(queries[0].domain, "google.com");
-    }
-
-    /// Only queries with a client similar to the input are returned.
-    #[test]
-    fn client() {
-        let params = HistoryParams {
-            client: Some("10.1".to_owned()),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert_eq!(queries[0].client, "10.1.1.1");
-    }
-
-    /// Only queries with an upstream similar to the input are returned.
-    #[test]
-    fn upstream() {
-        let params = HistoryParams {
-            upstream: Some("8.8.8".to_owned()),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert_eq!(queries[0].upstream, Some("8.8.8.8".to_owned()));
-    }
-
-    /// Only queries with the input query type are returned.
-    #[test]
-    fn query_type() {
-        let query_type = FtlQueryType::PTR;
-        let params = HistoryParams {
-            query_type: Some(query_type),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert_eq!(queries[0].query_type, query_type as i32);
-    }
-
-    /// Only queries with the input query status are returned.
-    #[test]
-    fn status() {
-        let status = FtlQueryStatus::Forward;
-        let params = HistoryParams {
-            status: Some(status),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert_eq!(queries[0].status, status as i32);
-    }
-
-    /// Only queries with a blocked/unblocked status are returned.
-    #[test]
-    fn blocked() {
-        let blocked = false;
-        let params = HistoryParams {
-            blocked: Some(blocked),
-            ..HistoryParams::default()
-        };
-
-        let (queries, _) =
-            load_queries_from_database(&connect_to_test_db(), None, &params, 1).unwrap();
-
-        assert_eq!(queries.len(), 1);
-        assert!(
-            match FtlQueryStatus::from_number(queries[0].status as isize).unwrap() {
-                FtlQueryStatus::Gravity
-                | FtlQueryStatus::Wildcard
-                | FtlQueryStatus::Blacklist
-                | FtlQueryStatus::ExternalBlock => blocked,
-                _ => !blocked
-            }
-        );
     }
 }

--- a/src/routes/stats/history/filters/blocked.rs
+++ b/src/routes/stats/history/filters/blocked.rs
@@ -8,7 +8,12 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use crate::{ftl::FtlQuery, routes::stats::history::endpoints::HistoryParams};
+use crate::{
+    databases::ftl::queries,
+    ftl::{FtlQuery, BLOCKED_STATUSES},
+    routes::stats::history::endpoints::HistoryParams
+};
+use diesel::{prelude::*, sqlite::Sqlite};
 
 /// Only show allowed/blocked queries
 pub fn filter_blocked<'a>(
@@ -26,13 +31,36 @@ pub fn filter_blocked<'a>(
     }
 }
 
+/// Only show allowed/blocked queries in database results
+pub fn filter_blocked_db<'a>(
+    db_query: queries::BoxedQuery<'a, Sqlite>,
+    params: &HistoryParams
+) -> queries::BoxedQuery<'a, Sqlite> {
+    // Use the Diesel DSL of this table for easy querying
+    use self::queries::dsl::*;
+
+    if let Some(blocked) = params.blocked {
+        if blocked {
+            db_query.filter(status.eq_any(&BLOCKED_STATUSES))
+        } else {
+            db_query.filter(status.ne_all(&BLOCKED_STATUSES))
+        }
+    } else {
+        db_query
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::filter_blocked;
+    use super::{filter_blocked, filter_blocked_db};
     use crate::{
-        ftl::FtlQuery,
-        routes::stats::history::{endpoints::HistoryParams, testing::test_queries}
+        databases::ftl::connect_to_test_db,
+        ftl::{FtlQuery, BLOCKED_STATUSES},
+        routes::stats::history::{
+            database::execute_query, endpoints::HistoryParams, testing::test_queries
+        }
     };
+    use diesel::prelude::*;
 
     /// Only return allowed/blocked queries
     #[test]
@@ -49,5 +77,25 @@ mod test {
         .collect();
 
         assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// Only queries with a blocked/unblocked status are returned. This is a
+    /// database filter.
+    #[test]
+    fn database() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let blocked = false;
+        let params = HistoryParams {
+            blocked: Some(blocked),
+            ..HistoryParams::default()
+        };
+
+        let db_query = filter_blocked_db(queries.into_boxed(), &params);
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        for query in filtered_queries {
+            assert!(!BLOCKED_STATUSES.contains(&(query.status as i32)));
+        }
     }
 }

--- a/src/routes/stats/history/filters/exclude_clients.rs
+++ b/src/routes/stats/history/filters/exclude_clients.rs
@@ -3,7 +3,7 @@
 // Network-wide ad blocking via your own hardware.
 //
 // API
-// SetupVars API_EXCLUDE_* Filters
+// SetupVars API_EXCLUDE_CLIENTS Filter
 //
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
@@ -17,53 +17,6 @@ use crate::{
 };
 use diesel::{prelude::*, sqlite::Sqlite};
 use std::collections::HashSet;
-
-/// Apply the `SetupVarsEntry::ApiExcludeDomains` setting
-pub fn filter_excluded_domains<'a>(
-    queries_iter: Box<dyn Iterator<Item = &'a FtlQuery> + 'a>,
-    env: &Env,
-    ftl_memory: &FtlMemory,
-    ftl_lock: &ShmLockGuard<'a>
-) -> Result<Box<dyn Iterator<Item = &'a FtlQuery> + 'a>, Error> {
-    // Get the excluded domains list
-    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
-    let excluded_domains: HashSet<&str> = excluded_domains
-        .split(',')
-        .filter(|s| !s.is_empty())
-        .collect();
-
-    // End early if there are no excluded domains
-    if excluded_domains.is_empty() {
-        return Ok(queries_iter);
-    }
-
-    // Find the domain IDs of the excluded domains
-    let counters = ftl_memory.counters(ftl_lock)?;
-    let strings = ftl_memory.strings(ftl_lock)?;
-    let domains = ftl_memory.domains(ftl_lock)?;
-    let excluded_domain_ids: HashSet<usize> = domains
-        .iter()
-        .take(counters.total_domains as usize)
-        .enumerate()
-        .filter_map(|(i, domain)| {
-            if excluded_domains.contains(domain.get_domain(&strings)) {
-                Some(i)
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    // End if no domains match the excluded domains
-    if excluded_domain_ids.is_empty() {
-        return Ok(queries_iter);
-    }
-
-    // Filter out the excluded domains using the domain IDs
-    Ok(Box::new(queries_iter.filter(move |query| {
-        !excluded_domain_ids.contains(&(query.domain_id as usize))
-    })))
-}
 
 /// Apply the `SetupVarsEntry::ApiExcludeClients` setting
 pub fn filter_excluded_clients<'a>(
@@ -115,29 +68,6 @@ pub fn filter_excluded_clients<'a>(
     })))
 }
 
-/// Apply the `SetupVarsEntry::ApiExcludeDomains` setting to database queries
-pub fn filter_excluded_domains_db<'a>(
-    db_query: queries::BoxedQuery<'a, Sqlite>,
-    env: &Env
-) -> Result<queries::BoxedQuery<'a, Sqlite>, Error> {
-    // Use the Diesel DSL of this table for easy querying
-    use self::queries::dsl::*;
-
-    // Get the excluded domains list
-    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
-    let excluded_domains: HashSet<String> = excluded_domains
-        .split(',')
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_owned())
-        .collect();
-
-    if excluded_domains.is_empty() {
-        Ok(db_query)
-    } else {
-        Ok(db_query.filter(domain.ne_all(excluded_domains)))
-    }
-}
-
 /// Apply the `SetupVarsEntry::ApiExcludeClients` setting to database queries
 pub fn filter_excluded_clients_db<'a>(
     db_query: queries::BoxedQuery<'a, Sqlite>,
@@ -163,10 +93,7 @@ pub fn filter_excluded_clients_db<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        filter_excluded_clients, filter_excluded_clients_db, filter_excluded_domains,
-        filter_excluded_domains_db
-    };
+    use super::{filter_excluded_clients, filter_excluded_clients_db};
     use crate::{
         databases::ftl::connect_to_test_db,
         env::{Config, Env, PiholeFile},
@@ -191,29 +118,6 @@ mod tests {
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> = queries.iter().collect();
         let filtered_queries: Vec<&FtlQuery> = filter_excluded_clients(
-            Box::new(queries.iter()),
-            &env,
-            &test_memory(),
-            &ShmLockGuard::Test
-        )
-        .unwrap()
-        .collect();
-
-        assert_eq!(filtered_queries, expected_queries);
-    }
-
-    /// No queries should be filtered out if `API_EXCLUDE_DOMAINS` is empty
-    #[test]
-    fn domains_empty() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=")
-                .build()
-        );
-        let queries = test_queries();
-        let expected_queries: Vec<&FtlQuery> = queries.iter().collect();
-        let filtered_queries: Vec<&FtlQuery> = filter_excluded_domains(
             Box::new(queries.iter()),
             &env,
             &test_memory(),
@@ -256,31 +160,6 @@ mod tests {
         assert_eq!(filtered_queries, expected_queries);
     }
 
-    /// Queries with a domain in the `API_EXCLUDE_DOMAINS` list should be
-    /// removed
-    #[test]
-    fn domains() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=domain2.com")
-                .build()
-        );
-        let queries = test_queries();
-        let expected_queries: Vec<&FtlQuery> =
-            queries.iter().filter(|query| query.id != 4).collect();
-        let filtered_queries: Vec<&FtlQuery> = filter_excluded_domains(
-            Box::new(queries.iter()),
-            &env,
-            &test_memory(),
-            &ShmLockGuard::Test
-        )
-        .unwrap()
-        .collect();
-
-        assert_eq!(filtered_queries, expected_queries);
-    }
-
     /// Queries with a client in the `API_EXCLUDE_CLIENTS` list should be
     /// removed. This is a database filter.
     #[test]
@@ -299,30 +178,5 @@ mod tests {
 
         assert_eq!(filtered_queries.len(), 1);
         assert_eq!(filtered_queries[0].client, "10.1.1.1".to_owned());
-    }
-
-    /// Queries with a domain in the `API_EXCLUDE_DOMAIN` list should be
-    /// removed. This is a database filter.
-    #[test]
-    fn domains_db() {
-        use crate::databases::ftl::queries::dsl::*;
-
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(
-                    PiholeFile::SetupVars,
-                    "API_EXCLUDE_DOMAINS=0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org"
-                )
-                .build()
-        );
-
-        let db_query = filter_excluded_domains_db(queries.into_boxed(), &env).unwrap();
-        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
-
-        for query in filtered_queries {
-            assert_ne!(query.domain, "0.ubuntu.pool.ntp.org".to_owned());
-            assert_ne!(query.domain, "1.ubuntu.pool.ntp.org".to_owned());
-        }
     }
 }

--- a/src/routes/stats/history/filters/exclude_domains.rs
+++ b/src/routes/stats/history/filters/exclude_domains.rs
@@ -1,0 +1,178 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// SetupVars API_EXCLUDE_DOMAINS Filter
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use crate::{
+    databases::ftl::queries,
+    env::Env,
+    ftl::{FtlMemory, FtlQuery, ShmLockGuard},
+    settings::{ConfigEntry, SetupVarsEntry},
+    util::Error
+};
+use diesel::{prelude::*, sqlite::Sqlite};
+use std::collections::HashSet;
+
+/// Apply the `SetupVarsEntry::ApiExcludeDomains` setting
+pub fn filter_excluded_domains<'a>(
+    queries_iter: Box<dyn Iterator<Item = &'a FtlQuery> + 'a>,
+    env: &Env,
+    ftl_memory: &FtlMemory,
+    ftl_lock: &ShmLockGuard<'a>
+) -> Result<Box<dyn Iterator<Item = &'a FtlQuery> + 'a>, Error> {
+    // Get the excluded domains list
+    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
+    let excluded_domains: HashSet<&str> = excluded_domains
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // End early if there are no excluded domains
+    if excluded_domains.is_empty() {
+        return Ok(queries_iter);
+    }
+
+    // Find the domain IDs of the excluded domains
+    let counters = ftl_memory.counters(ftl_lock)?;
+    let strings = ftl_memory.strings(ftl_lock)?;
+    let domains = ftl_memory.domains(ftl_lock)?;
+    let excluded_domain_ids: HashSet<usize> = domains
+        .iter()
+        .take(counters.total_domains as usize)
+        .enumerate()
+        .filter_map(|(i, domain)| {
+            if excluded_domains.contains(domain.get_domain(&strings)) {
+                Some(i)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // End if no domains match the excluded domains
+    if excluded_domain_ids.is_empty() {
+        return Ok(queries_iter);
+    }
+
+    // Filter out the excluded domains using the domain IDs
+    Ok(Box::new(queries_iter.filter(move |query| {
+        !excluded_domain_ids.contains(&(query.domain_id as usize))
+    })))
+}
+
+/// Apply the `SetupVarsEntry::ApiExcludeDomains` setting to database queries
+pub fn filter_excluded_domains_db<'a>(
+    db_query: queries::BoxedQuery<'a, Sqlite>,
+    env: &Env
+) -> Result<queries::BoxedQuery<'a, Sqlite>, Error> {
+    // Use the Diesel DSL of this table for easy querying
+    use self::queries::dsl::*;
+
+    // Get the excluded domains list
+    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
+    let excluded_domains: HashSet<String> = excluded_domains
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_owned())
+        .collect();
+
+    if excluded_domains.is_empty() {
+        Ok(db_query)
+    } else {
+        Ok(db_query.filter(domain.ne_all(excluded_domains)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_excluded_domains, filter_excluded_domains_db};
+    use crate::{
+        databases::ftl::connect_to_test_db,
+        env::{Config, Env, PiholeFile},
+        ftl::{FtlQuery, ShmLockGuard},
+        routes::stats::history::{
+            database::execute_query,
+            testing::{test_memory, test_queries}
+        },
+        testing::TestEnvBuilder
+    };
+    use diesel::prelude::*;
+
+    /// No queries should be filtered out if `API_EXCLUDE_DOMAINS` is empty
+    #[test]
+    fn domains_empty() {
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=")
+                .build()
+        );
+        let queries = test_queries();
+        let expected_queries: Vec<&FtlQuery> = queries.iter().collect();
+        let filtered_queries: Vec<&FtlQuery> = filter_excluded_domains(
+            Box::new(queries.iter()),
+            &env,
+            &test_memory(),
+            &ShmLockGuard::Test
+        )
+        .unwrap()
+        .collect();
+
+        assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// Queries with a domain in the `API_EXCLUDE_DOMAINS` list should be
+    /// removed
+    #[test]
+    fn domains() {
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=domain2.com")
+                .build()
+        );
+        let queries = test_queries();
+        let expected_queries: Vec<&FtlQuery> =
+            queries.iter().filter(|query| query.id != 4).collect();
+        let filtered_queries: Vec<&FtlQuery> = filter_excluded_domains(
+            Box::new(queries.iter()),
+            &env,
+            &test_memory(),
+            &ShmLockGuard::Test
+        )
+        .unwrap()
+        .collect();
+
+        assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// Queries with a domain in the `API_EXCLUDE_DOMAIN` list should be
+    /// removed. This is a database filter.
+    #[test]
+    fn domains_db() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(
+                    PiholeFile::SetupVars,
+                    "API_EXCLUDE_DOMAINS=0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org"
+                )
+                .build()
+        );
+
+        let db_query = filter_excluded_domains_db(queries.into_boxed(), &env).unwrap();
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        for query in filtered_queries {
+            assert_ne!(query.domain, "0.ubuntu.pool.ntp.org".to_owned());
+            assert_ne!(query.domain, "1.ubuntu.pool.ntp.org".to_owned());
+        }
+    }
+}

--- a/src/routes/stats/history/filters/mod.rs
+++ b/src/routes/stats/history/filters/mod.rs
@@ -12,16 +12,17 @@ mod blocked;
 mod client;
 mod dnssec;
 mod domain;
+mod exclude_clients;
+mod exclude_domains;
 mod private;
 mod query_type;
 mod reply;
 mod setup_vars;
-mod setup_vars_exclude;
 mod status;
 mod time;
 mod upstream;
 
 pub use self::{
-    blocked::*, client::*, dnssec::*, domain::*, private::*, query_type::*, reply::*,
-    setup_vars::*, setup_vars_exclude::*, status::*, time::*, upstream::*
+    blocked::*, client::*, dnssec::*, domain::*, exclude_clients::*, exclude_domains::*,
+    private::*, query_type::*, reply::*, setup_vars::*, status::*, time::*, upstream::*
 };

--- a/src/routes/stats/history/filters/mod.rs
+++ b/src/routes/stats/history/filters/mod.rs
@@ -16,11 +16,12 @@ mod private;
 mod query_type;
 mod reply;
 mod setup_vars;
+mod setup_vars_exclude;
 mod status;
 mod time;
 mod upstream;
 
 pub use self::{
     blocked::*, client::*, dnssec::*, domain::*, private::*, query_type::*, reply::*,
-    setup_vars::*, status::*, time::*, upstream::*
+    setup_vars::*, setup_vars_exclude::*, status::*, time::*, upstream::*
 };

--- a/src/routes/stats/history/filters/query_type.rs
+++ b/src/routes/stats/history/filters/query_type.rs
@@ -8,7 +8,10 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use crate::{ftl::FtlQuery, routes::stats::history::endpoints::HistoryParams};
+use crate::{
+    databases::ftl::queries, ftl::FtlQuery, routes::stats::history::endpoints::HistoryParams
+};
+use diesel::{prelude::*, sqlite::Sqlite};
 
 /// Only show queries with the specified query type
 pub fn filter_query_type<'a>(
@@ -22,17 +25,36 @@ pub fn filter_query_type<'a>(
     }
 }
 
+/// Only show queries with the specified query type in database results
+pub fn filter_query_type_db<'a>(
+    db_query: queries::BoxedQuery<'a, Sqlite>,
+    params: &HistoryParams
+) -> queries::BoxedQuery<'a, Sqlite> {
+    // Use the Diesel DSL of this table for easy querying
+    use self::queries::dsl::*;
+
+    if let Some(search_query_type) = params.query_type {
+        db_query.filter(query_type.eq(search_query_type as i32))
+    } else {
+        db_query
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::filter_query_type;
+    use super::{filter_query_type, filter_query_type_db};
     use crate::{
+        databases::ftl::connect_to_test_db,
         ftl::{FtlQuery, FtlQueryType},
-        routes::stats::history::{endpoints::HistoryParams, testing::test_queries}
+        routes::stats::history::{
+            database::execute_query, endpoints::HistoryParams, testing::test_queries
+        }
     };
+    use diesel::prelude::*;
 
     /// Only return queries with the specified query type
     #[test]
-    fn test_filter_query_type() {
+    fn query_type() {
         let queries = test_queries();
         let expected_queries = vec![&queries[0], &queries[3], &queries[6], &queries[8]];
         let filtered_queries: Vec<&FtlQuery> = filter_query_type(
@@ -45,5 +67,25 @@ mod test {
         .collect();
 
         assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// Only queries with the input query type are returned. This is a database
+    /// filter.
+    #[test]
+    fn database() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let expected_query_type = FtlQueryType::PTR;
+        let params = HistoryParams {
+            query_type: Some(expected_query_type),
+            ..HistoryParams::default()
+        };
+
+        let db_query = filter_query_type_db(queries.into_boxed(), &params);
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        for query in filtered_queries {
+            assert_eq!(query.query_type, expected_query_type as i32);
+        }
     }
 }

--- a/src/routes/stats/history/filters/setup_vars.rs
+++ b/src/routes/stats/history/filters/setup_vars.rs
@@ -63,7 +63,7 @@ mod test {
 
     /// No queries should be shown if `API_QUERY_LOG_SHOW` equals `nothing`
     #[test]
-    fn nothing() {
+    fn setting_is_nothing() {
         let env = Env::Test(
             Config::default(),
             TestEnvBuilder::new()
@@ -82,7 +82,7 @@ mod test {
     /// Only permitted queries should be shown if `API_QUERY_LOG_SHOW` equals
     /// `permittedonly`
     #[test]
-    fn permitted() {
+    fn setting_is_permitted() {
         let env = Env::Test(
             Config::default(),
             TestEnvBuilder::new()
@@ -108,7 +108,7 @@ mod test {
     /// Only blocked queries should be shown if `API_QUERY_LOG_SHOW` equals
     /// `blockedonly`
     #[test]
-    fn blocked() {
+    fn setting_is_blocked() {
         let env = Env::Test(
             Config::default(),
             TestEnvBuilder::new()
@@ -129,7 +129,7 @@ mod test {
     /// No queries should be shown if `API_QUERY_LOG_SHOW` equals `nothing`.
     /// This is a database filter.
     #[test]
-    fn nothing_db() {
+    fn setting_is_nothing_db() {
         use crate::databases::ftl::queries::dsl::*;
 
         let env = Env::Test(
@@ -148,7 +148,7 @@ mod test {
     /// Only permitted queries should be shown if `API_QUERY_LOG_SHOW` equals
     /// `permittedonly`. This is a database filter.
     #[test]
-    fn permitted_db() {
+    fn setting_is_permitted_db() {
         use crate::databases::ftl::queries::dsl::*;
 
         let env = Env::Test(
@@ -169,7 +169,7 @@ mod test {
     /// Only blocked queries should be shown if `API_QUERY_LOG_SHOW` equals
     /// `blockedonly`. This is a database filter
     #[test]
-    fn blocked_db() {
+    fn setting_is_blocked_db() {
         use crate::databases::ftl::queries::dsl::*;
 
         let env = Env::Test(

--- a/src/routes/stats/history/filters/setup_vars.rs
+++ b/src/routes/stats/history/filters/setup_vars.rs
@@ -9,11 +9,13 @@
 // Please see LICENSE file for your rights under this license.
 
 use crate::{
+    databases::ftl::queries,
     env::Env,
-    ftl::FtlQuery,
+    ftl::{FtlQuery, BLOCKED_STATUSES},
     settings::{ConfigEntry, SetupVarsEntry},
     util::Error
 };
+use diesel::{prelude::*, sqlite::Sqlite};
 use std::iter;
 
 /// Apply the `SetupVarsEntry::ApiQueryLogShow` setting (`permittedonly`,
@@ -30,19 +32,38 @@ pub fn filter_setup_vars_setting<'a>(
     })
 }
 
+/// Apply the `SetupVarsEntry::ApiQueryLogShow` setting (`permittedonly`,
+/// `blockedonly`, etc) to database results.
+pub fn filter_setup_vars_setting_db<'a>(
+    db_query: queries::BoxedQuery<'a, Sqlite>,
+    env: &Env
+) -> Result<queries::BoxedQuery<'a, Sqlite>, Error> {
+    // Use the Diesel DSL of this table for easy querying
+    use self::queries::dsl::*;
+
+    Ok(match SetupVarsEntry::ApiQueryLogShow.read(env)?.as_str() {
+        "permittedonly" => db_query.filter(status.ne_all(&BLOCKED_STATUSES)),
+        "blockedonly" => db_query.filter(status.eq_any(&BLOCKED_STATUSES)),
+        "nothing" => db_query.limit(0),
+        _ => db_query
+    })
+}
+
 #[cfg(test)]
 mod test {
-    use super::filter_setup_vars_setting;
+    use super::{filter_setup_vars_setting, filter_setup_vars_setting_db};
     use crate::{
+        databases::ftl::connect_to_test_db,
         env::{Config, Env, PiholeFile},
-        ftl::FtlQuery,
-        routes::stats::history::testing::test_queries,
+        ftl::{FtlQuery, BLOCKED_STATUSES},
+        routes::stats::history::{database::execute_query, testing::test_queries},
         testing::TestEnvBuilder
     };
+    use diesel::prelude::*;
 
     /// No queries should be shown if `API_QUERY_LOG_SHOW` equals `nothing`
     #[test]
-    fn test_filter_setup_vars_setting_nothing() {
+    fn nothing() {
         let env = Env::Test(
             Config::default(),
             TestEnvBuilder::new()
@@ -55,13 +76,13 @@ mod test {
                 .unwrap()
                 .collect();
 
-        assert_eq!(filtered_queries, Vec::<&FtlQuery>::new());
+        assert_eq!(filtered_queries.len(), 0);
     }
 
     /// Only permitted queries should be shown if `API_QUERY_LOG_SHOW` equals
     /// `permittedonly`
     #[test]
-    fn test_filter_setup_vars_setting_permitted() {
+    fn permitted() {
         let env = Env::Test(
             Config::default(),
             TestEnvBuilder::new()
@@ -87,7 +108,7 @@ mod test {
     /// Only blocked queries should be shown if `API_QUERY_LOG_SHOW` equals
     /// `blockedonly`
     #[test]
-    fn test_filter_setup_vars_setting_blocked() {
+    fn blocked() {
         let env = Env::Test(
             Config::default(),
             TestEnvBuilder::new()
@@ -103,5 +124,66 @@ mod test {
                 .collect();
 
         assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// No queries should be shown if `API_QUERY_LOG_SHOW` equals `nothing`.
+    /// This is a database filter.
+    #[test]
+    fn nothing_db() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=nothing")
+                .build()
+        );
+
+        let db_query = filter_setup_vars_setting_db(queries.into_boxed(), &env).unwrap();
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        assert_eq!(filtered_queries.len(), 0);
+    }
+
+    /// Only permitted queries should be shown if `API_QUERY_LOG_SHOW` equals
+    /// `permittedonly`. This is a database filter.
+    #[test]
+    fn permitted_db() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=permittedonly")
+                .build()
+        );
+
+        let db_query = filter_setup_vars_setting_db(queries.into_boxed(), &env).unwrap();
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        for query in filtered_queries {
+            assert!(!BLOCKED_STATUSES.contains(&(query.status as i32)));
+        }
+    }
+
+    /// Only blocked queries should be shown if `API_QUERY_LOG_SHOW` equals
+    /// `blockedonly`. This is a database filter
+    #[test]
+    fn blocked_db() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=blockedonly")
+                .build()
+        );
+
+        let db_query = filter_setup_vars_setting_db(queries.into_boxed(), &env).unwrap();
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        for query in filtered_queries {
+            assert!(BLOCKED_STATUSES.contains(&(query.status as i32)));
+        }
     }
 }

--- a/src/routes/stats/history/filters/setup_vars_exclude.rs
+++ b/src/routes/stats/history/filters/setup_vars_exclude.rs
@@ -1,0 +1,227 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// SetupVars API_EXCLUDE_* Filters
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use crate::{
+    env::Env,
+    ftl::{FtlMemory, FtlQuery, ShmLockGuard},
+    settings::{ConfigEntry, SetupVarsEntry},
+    util::Error
+};
+use std::collections::HashSet;
+
+/// Apply the `SetupVarsEntry::ApiExcludeDomains` setting
+pub fn filter_excluded_domains<'a>(
+    queries_iter: Box<dyn Iterator<Item = &'a FtlQuery> + 'a>,
+    env: &Env,
+    ftl_memory: &FtlMemory,
+    ftl_lock: &ShmLockGuard<'a>
+) -> Result<Box<dyn Iterator<Item = &'a FtlQuery> + 'a>, Error> {
+    // Get the excluded domains list
+    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
+    let excluded_domains: HashSet<&str> = excluded_domains
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // End early if there are no excluded domains
+    if excluded_domains.is_empty() {
+        return Ok(queries_iter);
+    }
+
+    // Find the domain IDs of the excluded domains
+    let counters = ftl_memory.counters(ftl_lock)?;
+    let strings = ftl_memory.strings(ftl_lock)?;
+    let domains = ftl_memory.domains(ftl_lock)?;
+    let excluded_domain_ids: HashSet<usize> = domains
+        .iter()
+        .take(counters.total_domains as usize)
+        .enumerate()
+        .filter_map(|(i, domain)| {
+            if excluded_domains.contains(domain.get_domain(&strings)) {
+                Some(i)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // End if no domains match the excluded domains
+    if excluded_domain_ids.is_empty() {
+        return Ok(queries_iter);
+    }
+
+    // Filter out the excluded domains using the domain IDs
+    Ok(Box::new(queries_iter.filter(move |query| {
+        !excluded_domain_ids.contains(&(query.domain_id as usize))
+    })))
+}
+
+/// Apply the `SetupVarsEntry::ApiExcludeClients` setting
+pub fn filter_excluded_clients<'a>(
+    queries_iter: Box<dyn Iterator<Item = &'a FtlQuery> + 'a>,
+    env: &Env,
+    ftl_memory: &FtlMemory,
+    ftl_lock: &ShmLockGuard<'a>
+) -> Result<Box<dyn Iterator<Item = &'a FtlQuery> + 'a>, Error> {
+    // Get the excluded clients list
+    let excluded_clients = SetupVarsEntry::ApiExcludeClients.read(env)?.to_lowercase();
+    let excluded_clients: HashSet<&str> = excluded_clients
+        .split(',')
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // End early if there are no excluded clients
+    if excluded_clients.is_empty() {
+        return Ok(queries_iter);
+    }
+
+    // Find the client IDs of the excluded clients
+    let counters = ftl_memory.counters(ftl_lock)?;
+    let strings = ftl_memory.strings(ftl_lock)?;
+    let clients = ftl_memory.clients(ftl_lock)?;
+    let excluded_client_ids: HashSet<usize> = clients
+        .iter()
+        .take(counters.total_clients as usize)
+        .enumerate()
+        .filter_map(|(i, client)| {
+            let ip = client.get_ip(&strings);
+            let name = client.get_name(&strings).unwrap_or_default();
+
+            if excluded_clients.contains(ip) || excluded_clients.contains(name) {
+                Some(i)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // End if no clients match the excluded clients
+    if excluded_client_ids.is_empty() {
+        return Ok(queries_iter);
+    }
+
+    // Filter out the excluded domains using the domain IDs
+    Ok(Box::new(queries_iter.filter(move |query| {
+        !excluded_client_ids.contains(&(query.client_id as usize))
+    })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_excluded_clients, filter_excluded_domains};
+    use crate::{
+        env::{Config, Env, PiholeFile},
+        ftl::{FtlQuery, ShmLockGuard},
+        routes::stats::history::testing::{test_memory, test_queries},
+        testing::TestEnvBuilder
+    };
+
+    /// No queries should be filtered out if `API_EXCLUDE_CLIENTS` is empty
+    #[test]
+    fn filter_clients_empty() {
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=")
+                .build()
+        );
+        let queries = test_queries();
+        let expected_queries: Vec<&FtlQuery> = queries.iter().collect();
+        let filtered_queries: Vec<&FtlQuery> = filter_excluded_clients(
+            Box::new(queries.iter()),
+            &env,
+            &test_memory(),
+            &ShmLockGuard::Test
+        )
+        .unwrap()
+        .collect();
+
+        assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// No queries should be filtered out if `API_EXCLUDE_DOMAINS` is empty
+    #[test]
+    fn filter_domains_empty() {
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=")
+                .build()
+        );
+        let queries = test_queries();
+        let expected_queries: Vec<&FtlQuery> = queries.iter().collect();
+        let filtered_queries: Vec<&FtlQuery> = filter_excluded_domains(
+            Box::new(queries.iter()),
+            &env,
+            &test_memory(),
+            &ShmLockGuard::Test
+        )
+        .unwrap()
+        .collect();
+
+        assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// Queries with a client in the `API_EXCLUDE_CLIENTS` list should be
+    /// removed
+    #[test]
+    fn filter_clients() {
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=192.168.1.11")
+                .build()
+        );
+        let queries = test_queries();
+        let expected_queries = vec![
+            &queries[0],
+            &queries[1],
+            &queries[2],
+            &queries[6],
+            &queries[7],
+            &queries[8],
+        ];
+        let filtered_queries: Vec<&FtlQuery> = filter_excluded_clients(
+            Box::new(queries.iter()),
+            &env,
+            &test_memory(),
+            &ShmLockGuard::Test
+        )
+        .unwrap()
+        .collect();
+
+        assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// Queries with a domain in the `API_EXCLUDE_DOMAINS` list should be
+    /// removed
+    #[test]
+    fn filter_domains() {
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=domain2.com")
+                .build()
+        );
+        let queries = test_queries();
+        let expected_queries: Vec<&FtlQuery> =
+            queries.iter().filter(|query| query.id != 4).collect();
+        let filtered_queries: Vec<&FtlQuery> = filter_excluded_domains(
+            Box::new(queries.iter()),
+            &env,
+            &test_memory(),
+            &ShmLockGuard::Test
+        )
+        .unwrap()
+        .collect();
+
+        assert_eq!(filtered_queries, expected_queries);
+    }
+}

--- a/src/routes/stats/history/filters/time.rs
+++ b/src/routes/stats/history/filters/time.rs
@@ -8,7 +8,10 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use crate::{ftl::FtlQuery, routes::stats::history::endpoints::HistoryParams};
+use crate::{
+    databases::ftl::queries, ftl::FtlQuery, routes::stats::history::endpoints::HistoryParams
+};
+use diesel::{prelude::*, sqlite::Sqlite};
 
 /// Filter out queries before the `from` timestamp
 pub fn filter_time_from<'a>(
@@ -34,17 +37,51 @@ pub fn filter_time_until<'a>(
     }
 }
 
+/// Filter out queries before the `from` timestamp in database results
+pub fn filter_time_from_db<'a>(
+    db_query: queries::BoxedQuery<'a, Sqlite>,
+    params: &HistoryParams
+) -> queries::BoxedQuery<'a, Sqlite> {
+    // Use the Diesel DSL of this table for easy querying
+    use self::queries::dsl::*;
+
+    if let Some(from) = params.from {
+        db_query.filter(timestamp.ge(from as i32))
+    } else {
+        db_query
+    }
+}
+
+/// Filter out queries after the `until` timestamp in database results
+pub fn filter_time_until_db<'a>(
+    db_query: queries::BoxedQuery<'a, Sqlite>,
+    params: &HistoryParams
+) -> queries::BoxedQuery<'a, Sqlite> {
+    // Use the Diesel DSL of this table for easy querying
+    use self::queries::dsl::*;
+
+    if let Some(until) = params.until {
+        db_query.filter(timestamp.le(until as i32))
+    } else {
+        db_query
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use super::{filter_time_from, filter_time_until};
+    use super::{filter_time_from, filter_time_from_db, filter_time_until, filter_time_until_db};
     use crate::{
+        databases::ftl::connect_to_test_db,
         ftl::FtlQuery,
-        routes::stats::history::{endpoints::HistoryParams, testing::test_queries}
+        routes::stats::history::{
+            database::execute_query, endpoints::HistoryParams, testing::test_queries
+        }
     };
+    use diesel::prelude::*;
 
     /// Skip queries before the timestamp
     #[test]
-    fn test_filter_time_from() {
+    fn from() {
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> = queries.iter().skip(4).collect();
         let filtered_queries: Vec<&FtlQuery> = filter_time_from(
@@ -61,7 +98,7 @@ mod test {
 
     /// Skip queries after the timestamp
     #[test]
-    fn test_filter_time_until() {
+    fn until() {
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> = queries.iter().take(5).collect();
         let filtered_queries: Vec<&FtlQuery> = filter_time_until(
@@ -74,5 +111,43 @@ mod test {
         .collect();
 
         assert_eq!(filtered_queries, expected_queries);
+    }
+
+    /// Only queries newer than `from` are returned. This is a database filter.
+    #[test]
+    fn from_db() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let from = 177_179;
+        let params = HistoryParams {
+            from: Some(from),
+            ..HistoryParams::default()
+        };
+
+        let db_query = filter_time_from_db(queries.into_boxed(), &params);
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        assert!(filtered_queries
+            .iter()
+            .all(|query| query.timestamp >= from as i32));
+    }
+
+    /// Only queries older than `until` are returned. This is a database filter.
+    #[test]
+    fn until_db() {
+        use crate::databases::ftl::queries::dsl::*;
+
+        let until = 1;
+        let params = HistoryParams {
+            until: Some(until),
+            ..HistoryParams::default()
+        };
+
+        let db_query = filter_time_until_db(queries.into_boxed(), &params);
+        let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
+
+        assert!(filtered_queries
+            .iter()
+            .all(|query| query.timestamp <= until as i32));
     }
 }

--- a/src/routes/stats/history/get_history.rs
+++ b/src/routes/stats/history/get_history.rs
@@ -89,6 +89,8 @@ pub fn get_history(
     let queries_iter = filter_blocked(queries_iter, &params);
     let queries_iter = filter_dnssec(queries_iter, &params);
     let queries_iter = filter_reply(queries_iter, &params);
+    let queries_iter = filter_excluded_domains(queries_iter, env, ftl_memory, &lock)?;
+    let queries_iter = filter_excluded_clients(queries_iter, env, ftl_memory, &lock)?;
 
     // Get the limit
     let limit = params.limit.unwrap_or(100);

--- a/src/routes/stats/history/get_history.rs
+++ b/src/routes/stats/history/get_history.rs
@@ -151,7 +151,7 @@ pub fn get_history(
     {
         // Load queries from the database
         let (db_queries, cursor) =
-            load_queries_from_database(db as &SqliteConnection, last_db_id, &params, limit)?;
+            load_queries_from_database(db as &SqliteConnection, last_db_id, &params, env, limit)?;
 
         // Map the queries into JSON
         let db_queries = db_queries.into_iter().map(Into::into);


### PR DESCRIPTION
This PR does a few major things:
- Organizes the database filters into separate files, like what was previously done for the in-memory filters. The database and in-memory filters now sit in the same file, so they are organized and easy to find.
- Implement in-memory and database filters for `API_EXCLUDE_CLIENTS` and `API_EXCLUDE_DOMAINS`. This closes #93 
- Implement database filter for `API_QUERY_LOG_SHOW`. This must have been forgotten when the first database query filters were made.

And a few minor things:
- When getting excluded clients/domains, the data structure used was changed from a `Vec` to `HashSet` for performance reasons.
- The list of blocked statuses was made static, so there is a single reference to the statuses that are considered blocked.
- `connect_to_test_db` was moved to the `databases::ftl` module.