### PR TITLE
Add misc:Depends to dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Build-Depends: debhelper (>= 10), dh-systemd (>= 1.5)
 
 Package: pihole-api
 Architecture: any
-Depends: libsqlite3-0, libcap2-bin, ${shlibs:Depends}
+Depends: libsqlite3-0, libcap2-bin, ${shlibs:Depends}, ${misc:Depends}
 Description: The Pi-hole API, including the Web Interface
  The Pi-hole API provides a RESTful service for the web interface. The web
  interface is embedded into the API and exposed under /admin.


### PR DESCRIPTION
This is a list of dependencies used by some debhelper tools, depending on the package configuration.

I had this in my local branch, but forgot to push before #96 was merged.