### PR TITLE
Use armv7 for armhf binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
     <<: *job_template
     environment:
       BIN_NAME: "pihole-API-arm-linux-gnueabihf"
-      TARGET: "arm-unknown-linux-gnueabihf"
+      TARGET: "armv7-unknown-linux-gnueabihf"
       DEB_ARCH: "armhf"
 
   aarch64:

--- a/docker/armhf/Dockerfile
+++ b/docker/armhf/Dockerfile
@@ -8,9 +8,9 @@ RUN dpkg --add-architecture armhf && \
     rm -rf /var/lib/apt/lists/* && \
     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2019-01-09 && \
     export PATH="/root/.cargo/bin:$PATH" && \
-    rustup target add arm-unknown-linux-gnueabihf
+    rustup target add armv7-unknown-linux-gnueabihf
 
 ENV PATH="/root/.cargo/bin:$PATH" \
     TARGET_CC=arm-linux-gnueabihf-gcc \
-    CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
-    CC_arm_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc
+    CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc


### PR DESCRIPTION
Debian uses armv7 for the armhf architecture, and FTL's armhf build uses armv7 (because it uses the armhf gcc in Debian). The API currently uses Rust's arm-unknown-linux-gnueabihf target for the armhf build, but that uses armv6 in order to be compatible with older Raspberry Pi's such as the Pi 1B and Pi Zero. The armv7-unknown-linux-gnueabihf target is the equivalent of Debian's armhf architecture. Because FTL uses armv7 for the armhf build, API should also use armv7 for its armhf build.