### PR TITLE
Add database overTime history endpoint

### DIFF
--- a/src/routes/stats/database/mod.rs
+++ b/src/routes/stats/database/mod.rs
@@ -8,6 +8,7 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
+mod over_time_history_db;
 mod summary_db;
 
-pub use self::summary_db::*;
+pub use self::{over_time_history_db::*, summary_db::*};

--- a/src/routes/stats/database/over_time_history_db.rs
+++ b/src/routes/stats/database/over_time_history_db.rs
@@ -1,0 +1,215 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// Query History Over Time Database Endpoint
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use crate::{
+    databases::ftl::FtlDatabase,
+    ftl::BLOCKED_STATUSES,
+    routes::{auth::User, stats::over_time_history::OverTimeItem},
+    util::{reply_data, Error, ErrorKind, Reply}
+};
+use diesel::{dsl::sql, prelude::*, sql_types::BigInt};
+use failure::ResultExt;
+use std::collections::HashMap;
+
+/// Get the query history over time from the database
+/// (separated into blocked and not blocked)
+#[get("/stats/database/overTime/history?<from>&<until>&<interval>")]
+pub fn over_time_history_db(
+    from: u64,
+    until: u64,
+    interval: Option<usize>,
+    _auth: User,
+    db: FtlDatabase
+) -> Reply {
+    reply_data(over_time_history_db_impl(
+        from,
+        until,
+        interval.unwrap_or(600),
+        &db as &SqliteConnection
+    )?)
+}
+
+/// Get the over time data from the database
+fn over_time_history_db_impl(
+    from: u64,
+    until: u64,
+    interval: usize,
+    db: &SqliteConnection
+) -> Result<Vec<OverTimeItem>, Error> {
+    let is_range_increasing = from < until;
+
+    if !is_range_increasing {
+        // The timestamps should increase from "from" to "until"
+        return Err(Error::from(ErrorKind::BadRequest));
+    }
+
+    // Align timestamps with the interval
+    let from = from - (from % interval as u64);
+    let until = if until % interval as u64 != 0 {
+        until - (until % interval as u64) + interval as u64
+    } else {
+        until
+    };
+
+    // Get the overTime data
+    let total_intervals = get_total_intervals(from, until, interval, db)?;
+    let blocked_intervals = get_blocked_intervals(from, until, interval, db)?;
+
+    let mut over_time: Vec<OverTimeItem> = Vec::with_capacity((until - from) as usize / interval);
+
+    // For each interval's timestamp, create the overTime slot
+    for timestamp in (from..=until).step_by(interval) {
+        let timestamp_key = &(timestamp as i32);
+        let total_queries = *total_intervals.get(timestamp_key).unwrap_or(&0) as usize;
+        let blocked_queries = *blocked_intervals.get(timestamp_key).unwrap_or(&0) as usize;
+
+        over_time.push(OverTimeItem {
+            timestamp,
+            total_queries,
+            blocked_queries
+        });
+    }
+
+    Ok(over_time)
+}
+
+/// Get the over time data for all queries from the database
+fn get_total_intervals(
+    from: u64,
+    until: u64,
+    interval: usize,
+    db: &SqliteConnection
+) -> Result<HashMap<i32, i64>, Error> {
+    use crate::databases::ftl::queries::dsl::*;
+
+    // SQL snippet for calculating the interval timestamp of the query
+    let interval_sql = sql(&format!(
+        "(timestamp / {interval}) * {interval}",
+        interval = interval
+    ));
+
+    // Create SQL query
+    let sql_query = queries
+        .select((&interval_sql, sql::<BigInt>("COUNT(*)")))
+        .filter(status.ne(0))
+        .filter(timestamp.ge(from as i32))
+        .filter(timestamp.le(until as i32))
+        .order_by(&interval_sql)
+        .group_by(&interval_sql);
+
+    // Execute SQL query
+    Ok(sql_query
+        .load(&db as &SqliteConnection)
+        .context(ErrorKind::FtlDatabase)?
+        // Convert to HashMap
+        .into_iter()
+        .collect())
+}
+
+/// Get the over time data for blocked queries from the database
+fn get_blocked_intervals(
+    from: u64,
+    until: u64,
+    interval: usize,
+    db: &SqliteConnection
+) -> Result<HashMap<i32, i64>, Error> {
+    use crate::databases::ftl::queries::dsl::*;
+
+    // SQL snippet for calculating the interval timestamp of the query
+    let interval_sql = sql(&format!(
+        "(timestamp / {interval}) * {interval}",
+        interval = interval
+    ));
+
+    // Create SQL query
+    let sql_query = queries
+        .select((&interval_sql, sql::<BigInt>("COUNT(*)")))
+        .filter(status.eq_any(&BLOCKED_STATUSES))
+        .filter(timestamp.ge(from as i32))
+        .filter(timestamp.le(until as i32))
+        .order_by(&interval_sql)
+        .group_by(&interval_sql);
+
+    // Execute SQL query
+    Ok(sql_query
+        .load(&db as &SqliteConnection)
+        .context(ErrorKind::FtlDatabase)?
+        // Convert to HashMap
+        .into_iter()
+        .collect())
+}
+
+#[cfg(test)]
+mod test {
+    use super::{get_blocked_intervals, get_total_intervals, over_time_history_db_impl};
+    use crate::{
+        databases::ftl::connect_to_test_db, routes::stats::over_time_history::OverTimeItem
+    };
+    use std::collections::HashMap;
+
+    const FROM_TIMESTAMP: u64 = 164_400;
+    const UNTIL_TIMESTAMP: u64 = 177_000;
+    const INTERVAL: usize = 600;
+
+    /// Verify the over time data is retrieved correctly
+    #[test]
+    fn over_time_history_impl() {
+        let expected = vec![
+            OverTimeItem {
+                timestamp: 164_400,
+                total_queries: 26,
+                blocked_queries: 0
+            },
+            OverTimeItem {
+                timestamp: 165_000,
+                total_queries: 7,
+                blocked_queries: 0
+            },
+            OverTimeItem {
+                timestamp: 165_600,
+                total_queries: 0,
+                blocked_queries: 0
+            },
+        ];
+
+        let db = connect_to_test_db();
+        let actual = over_time_history_db_impl(164_400, 165_600, 600, &db).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    /// Verify the total intervals are retrieved correctly
+    #[test]
+    fn total_intervals() {
+        let mut expected = HashMap::new();
+        expected.insert(164_400, 26);
+        expected.insert(165_000, 7);
+        expected.insert(168_600, 3);
+        expected.insert(172_200, 3);
+        expected.insert(174_000, 8);
+        expected.insert(175_800, 3);
+
+        let db = connect_to_test_db();
+        let actual = get_total_intervals(FROM_TIMESTAMP, UNTIL_TIMESTAMP, INTERVAL, &db).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    /// Verify the blocked intervals are retrieved correctly (there are none)
+    #[test]
+    fn blocked_intervals() {
+        let expected = HashMap::new();
+
+        let db = connect_to_test_db();
+        let actual = get_blocked_intervals(FROM_TIMESTAMP, UNTIL_TIMESTAMP, INTERVAL, &db).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -165,6 +165,7 @@ fn setup(
             stats::over_time_history,
             stats::over_time_clients,
             stats::database::get_summary_db,
+            stats::database::over_time_history_db,
             dns::get_whitelist,
             dns::get_blacklist,
             dns::get_regexlist,


### PR DESCRIPTION
Given a from timestamp, until timestamp, and optional interval (in seconds), this endpoint will return data for the over time graph. The response format is the same as `/stats/overTime/history`.

The previous over time endpoint now uses a shared `OverTimeItem` struct.

See #88 