### PR TITLE
Combine endpoints with parameters, and fix limit handling on some endpoints

### DIFF
--- a/src/routes/stats/clients.rs
+++ b/src/routes/stats/clients.rs
@@ -21,15 +21,9 @@ use crate::{
 use rocket::{request::Form, State};
 use rocket_contrib::json::JsonValue;
 
-/// Get the client information with default parameters
-#[get("/stats/clients")]
-pub fn clients(_auth: User, ftl_memory: State<FtlMemory>, env: State<Env>) -> Reply {
-    get_clients(&ftl_memory, &env, ClientParams::default())
-}
-
-/// Get the client information with specified parameters
+/// Get client information
 #[get("/stats/clients?<params..>")]
-pub fn clients_params(
+pub fn clients(
     _auth: User,
     ftl_memory: State<FtlMemory>,
     env: State<Env>,
@@ -42,14 +36,6 @@ pub fn clients_params(
 #[derive(FromForm)]
 pub struct ClientParams {
     inactive: Option<bool>
-}
-
-impl Default for ClientParams {
-    fn default() -> Self {
-        ClientParams {
-            inactive: Some(false)
-        }
-    }
 }
 
 /// Get client info according to the parameters

--- a/src/routes/stats/history/endpoints.rs
+++ b/src/routes/stats/history/endpoints.rs
@@ -23,20 +23,9 @@ use rocket::{
     State
 };
 
-/// Get the entire query history (as stored in FTL)
-#[get("/stats/history")]
-pub fn history(
-    _auth: User,
-    ftl_memory: State<FtlMemory>,
-    env: State<Env>,
-    db: FtlDatabase
-) -> Reply {
-    get_history(&ftl_memory, &env, HistoryParams::default(), &db)
-}
-
 /// Get the query history according to the specified parameters
 #[get("/stats/history?<params..>")]
-pub fn history_params(
+pub fn history(
     _auth: User,
     ftl_memory: State<FtlMemory>,
     env: State<Env>,

--- a/src/routes/stats/recent_blocked.rs
+++ b/src/routes/stats/recent_blocked.rs
@@ -17,27 +17,21 @@ use crate::{
 };
 use rocket::{request::Form, State};
 
-/// Get the most recent blocked domain
-#[get("/stats/recent_blocked")]
-pub fn recent_blocked(_auth: User, ftl_memory: State<FtlMemory>, env: State<Env>) -> Reply {
-    get_recent_blocked(&ftl_memory, &env, 1)
-}
-
 /// Get the `num` most recently blocked domains
 #[get("/stats/recent_blocked?<params..>")]
-pub fn recent_blocked_params(
+pub fn recent_blocked(
     _auth: User,
     ftl_memory: State<FtlMemory>,
     env: State<Env>,
     params: Form<RecentBlockedParams>
 ) -> Reply {
-    get_recent_blocked(&ftl_memory, &env, params.num)
+    get_recent_blocked(&ftl_memory, &env, params.num.unwrap_or(1))
 }
 
 /// Represents the possible GET parameters on `/stats/recent_blocked`
 #[derive(FromForm)]
 pub struct RecentBlockedParams {
-    num: usize
+    num: Option<usize>
 }
 
 /// Get `num`-many most recently blocked domains

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -155,7 +155,6 @@ fn setup(
             stats::upstreams,
             stats::query_types,
             stats::history,
-            stats::history_params,
             stats::recent_blocked,
             stats::recent_blocked_params,
             stats::clients,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -156,7 +156,6 @@ fn setup(
             stats::query_types,
             stats::history,
             stats::recent_blocked,
-            stats::recent_blocked_params,
             stats::clients,
             stats::clients_params,
             stats::over_time_history,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -152,7 +152,6 @@ fn setup(
             stats::get_summary,
             stats::top_domains,
             stats::top_clients,
-            stats::top_clients_params,
             stats::upstreams,
             stats::query_types,
             stats::history,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -151,7 +151,6 @@ fn setup(
             auth::logout,
             stats::get_summary,
             stats::top_domains,
-            stats::top_domains_params,
             stats::top_clients,
             stats::top_clients_params,
             stats::upstreams,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -157,7 +157,6 @@ fn setup(
             stats::history,
             stats::recent_blocked,
             stats::clients,
-            stats::clients_params,
             stats::over_time_history,
             stats::over_time_clients,
             stats::database::get_summary_db,


### PR DESCRIPTION
A few endpoints have two versions, one without GET parameters and one with parameters. The original idea was that requests without parameters would be handled by the former endpoint, and requests with parameters would be handled by the latter. It turns out that the former endpoint (without parameters) is never used in most cases, because the parameters are all optional.

Rocket checks endpoints which could handle an incoming request in a certain order, according to their rank: https://rocket.rs/v0.4/guide/requests/#default-ranking
In general, more specific endpoints are used before more general ones. This causes the endpoint with parameters to be used instead of the one without parameters.

Endpoints with both handler versions have been combined.

The following fixes are also part of this PR:
- Top domains has a default limit of 10 items. This was intended before, but due to a bug there was no default limit.
- Top clients has a default limit of 10 items. This was not part of the code before, but to be consistent with top domains it was changed.