### PR TITLE
Update supported shared memory version to 4

### DIFF
--- a/src/ftl/memory_model/counters.rs
+++ b/src/ftl/memory_model/counters.rs
@@ -27,7 +27,7 @@ pub struct FtlCounters {
     pub upstream_capacity: libc::c_int,
     pub client_capacity: libc::c_int,
     pub domain_capacity: libc::c_int,
-    pub over_time_capacity: libc::c_int,
+    pub string_capacity: libc::c_int,
     pub gravity_size: libc::c_int,
     pub gravity_conf: libc::c_int,
     pub query_type_counters: [libc::c_int; 7],

--- a/src/ftl/memory_model/settings.rs
+++ b/src/ftl/memory_model/settings.rs
@@ -14,11 +14,17 @@ use libc;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct FtlSettings {
-    pub version: libc::c_int
+    pub version: libc::c_int,
+    pub global_shm_counter: libc::c_uint,
+    pub next_str_pos: libc::c_uint
 }
 
 impl Default for FtlSettings {
     fn default() -> Self {
-        FtlSettings { version: 0 }
+        FtlSettings {
+            version: 0,
+            global_shm_counter: 0,
+            next_str_pos: 1 // 0 is used as the empty string
+        }
     }
 }

--- a/src/ftl/shared_memory.rs
+++ b/src/ftl/shared_memory.rs
@@ -22,7 +22,7 @@ use crate::{ftl::memory_model::FtlSettings, util::ErrorKind};
 #[cfg(test)]
 use std::collections::HashMap;
 
-const FTL_SHM_VERSION: usize = 3;
+const FTL_SHM_VERSION: usize = 4;
 
 const FTL_SHM_CLIENTS: &str = "/FTL-clients";
 const FTL_SHM_DOMAINS: &str = "/FTL-domains";


### PR DESCRIPTION
Only minor changes are required. None of the affected attributes are currently used by the API.