### PR TITLE
Allow reading the web interface settings when not signed in

### DIFF
--- a/src/routes/settings/web.rs
+++ b/src/routes/settings/web.rs
@@ -19,7 +19,7 @@ use rocket_contrib::json::Json;
 
 /// Get web interface settings
 #[get("/settings/web")]
-pub fn get_web(_auth: User, env: State<Env>) -> Reply {
+pub fn get_web(env: State<Env>) -> Reply {
     let settings = WebSettings {
         layout: SetupVarsEntry::WebLayout.read(&env)?,
         language: SetupVarsEntry::WebLanguage.read(&env)?


### PR DESCRIPTION
The settings should be usable by all users. Otherwise, settings such as the language would only be applied when the user has logged in.