### PR TITLE
Add database overTime clients endpoint

### DIFF
--- a/src/ftl/memory_model/client.rs
+++ b/src/ftl/memory_model/client.rs
@@ -21,6 +21,7 @@ use std::fmt::{
 
 /// Represents an FTL client in API responses
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct ClientReply {
     pub name: String,
     pub ip: String

--- a/src/ftl/memory_model/client.rs
+++ b/src/ftl/memory_model/client.rs
@@ -19,6 +19,13 @@ use std::fmt::{
     self, {Debug, Formatter}
 };
 
+/// Represents an FTL client in API responses
+#[derive(Serialize)]
+pub struct ClientReply {
+    pub name: String,
+    pub ip: String
+}
+
 /// The client struct stored in shared memory.
 ///
 /// Many traits, such as Debug and PartialEq, have to be manually implemented
@@ -88,6 +95,17 @@ impl FtlClient {
             strings.get_str(self.name_str_id as usize)
         } else {
             None
+        }
+    }
+
+    /// Convert this FTL client into the reply format
+    pub fn as_reply(&self, strings: &FtlStrings) -> ClientReply {
+        let name = self.get_name(&strings).unwrap_or_default();
+        let ip = self.get_ip(&strings);
+
+        ClientReply {
+            name: name.to_owned(),
+            ip: ip.to_owned()
         }
     }
 }

--- a/src/ftl/memory_model/mod.rs
+++ b/src/ftl/memory_model/mod.rs
@@ -26,7 +26,7 @@ mod strings;
 mod upstream;
 
 pub use self::{
-    client::FtlClient,
+    client::*,
     counters::{FtlCounters, FtlQueryType},
     domain::{FtlDomain, FtlRegexMatch},
     lock::FtlLock,

--- a/src/routes/stats/common.rs
+++ b/src/routes/stats/common.rs
@@ -29,11 +29,12 @@ pub fn remove_excluded_clients(
     env: &Env,
     strings: &FtlStrings
 ) -> Result<(), Error> {
-    let excluded_clients = SetupVarsEntry::ApiExcludeClients.read(env)?.to_lowercase();
-    let excluded_clients: HashSet<&str> = excluded_clients
-        .split(',')
-        .filter(|s| !s.is_empty())
+    let excluded_clients: Vec<String> = SetupVarsEntry::ApiExcludeClients
+        .read_list(env)?
+        .into_iter()
+        .map(|s| s.to_lowercase())
         .collect();
+    let excluded_clients: HashSet<&str> = excluded_clients.iter().map(String::as_str).collect();
 
     if !excluded_clients.is_empty() {
         // Only retain clients which do not appear in the exclusion list
@@ -58,11 +59,12 @@ pub fn remove_excluded_domains(
     env: &Env,
     strings: &FtlStrings
 ) -> Result<(), Error> {
-    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
-    let excluded_domains: HashSet<&str> = excluded_domains
-        .split(',')
-        .filter(|s| !s.is_empty())
+    let excluded_domains: Vec<String> = SetupVarsEntry::ApiExcludeDomains
+        .read_list(env)?
+        .into_iter()
+        .map(|s| s.to_lowercase())
         .collect();
+    let excluded_domains: HashSet<&str> = excluded_domains.iter().map(String::as_str).collect();
 
     if !excluded_domains.is_empty() {
         // Only retain domains which do not appear in the exclusion list

--- a/src/routes/stats/common.rs
+++ b/src/routes/stats/common.rs
@@ -49,6 +49,29 @@ pub fn remove_excluded_clients(
     Ok(())
 }
 
+/// Remove client identifiers from the `client_identifiers` vector if they show
+/// up in [`SetupVarsEntry::ApiExcludeClients`].
+///
+/// [`SetupVarsEntry::ApiExcludeClients`]:
+/// ../../../settings/entries/enum.SetupVarsEntry.html#variant.ApiExcludeClients
+pub fn remove_excluded_clients_db(
+    client_identifiers: &mut Vec<String>,
+    env: &Env
+) -> Result<(), Error> {
+    let excluded_clients: HashSet<String> = SetupVarsEntry::ApiExcludeClients
+        .read_list(env)?
+        .into_iter()
+        .map(|s| s.to_lowercase())
+        .collect();
+
+    if !excluded_clients.is_empty() {
+        // Only retain clients which do not appear in the exclusion list
+        client_identifiers.retain(|client_identifier| !excluded_clients.contains(client_identifier))
+    }
+
+    Ok(())
+}
+
 /// Remove domains from the `domains` vector if they show up in
 /// [`SetupVarsEntry::ApiExcludeDomains`].
 ///
@@ -78,6 +101,12 @@ pub fn remove_excluded_domains(
 /// to the privacy level.
 pub fn remove_hidden_clients(clients: &mut Vec<&FtlClient>, strings: &FtlStrings) {
     clients.retain(|client| client.get_ip(strings) != "0.0.0.0");
+}
+
+/// Remove client identifiers from the `client_identifiers` vector if they are
+/// marked as hidden due to the privacy level.
+pub fn remove_hidden_clients_db(client_identifiers: &mut Vec<String>) {
+    client_identifiers.retain(|client| client != "0.0.0.0")
 }
 
 /// Remove domains from the `domains` vector if they are marked as hidden due
@@ -112,8 +141,8 @@ pub fn get_current_over_time_slot(over_time: &[FtlOverTime]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{
-        remove_excluded_clients, remove_excluded_domains, remove_hidden_clients,
-        remove_hidden_domains
+        remove_excluded_clients, remove_excluded_clients_db, remove_excluded_domains,
+        remove_hidden_clients, remove_hidden_clients_db, remove_hidden_domains
     };
     use crate::{
         env::{Config, Env, PiholeFile},
@@ -184,6 +213,32 @@ mod tests {
         assert_eq!(clients, vec![&FtlClient::new(0, 0, 4, None)]);
     }
 
+    /// Clients marked as excluded are removed
+    #[test]
+    fn excluded_clients_db() {
+        let expected = vec!["0.0.0.0".to_owned()];
+
+        let env = Env::Test(
+            Config::default(),
+            TestEnvBuilder::new()
+                .file(
+                    PiholeFile::SetupVars,
+                    "API_EXCLUDE_CLIENTS=10.1.1.2,client1"
+                )
+                .build()
+        );
+
+        let mut clients = vec![
+            "client1".to_owned(),
+            "10.1.1.2".to_owned(),
+            "0.0.0.0".to_owned(),
+        ];
+
+        remove_excluded_clients_db(&mut clients, &env).unwrap();
+
+        assert_eq!(clients, expected);
+    }
+
     /// Domains marked as excluded are removed
     #[test]
     fn excluded_domains() {
@@ -233,6 +288,22 @@ mod tests {
         remove_hidden_clients(&mut clients, &ftl_memory.strings(&lock_guard).unwrap());
 
         assert_eq!(clients, clients_clone);
+    }
+
+    /// Clients marked as hidden are removed
+    #[test]
+    fn hidden_clients_db() {
+        let expected = vec!["client1".to_owned(), "10.1.1.2".to_owned()];
+
+        let mut clients = vec![
+            "client1".to_owned(),
+            "10.1.1.2".to_owned(),
+            "0.0.0.0".to_owned(),
+        ];
+
+        remove_hidden_clients_db(&mut clients);
+
+        assert_eq!(clients, expected);
     }
 
     /// Domains marked as hidden are removed

--- a/src/routes/stats/common.rs
+++ b/src/routes/stats/common.rs
@@ -45,7 +45,7 @@ pub fn remove_excluded_clients(
     Ok(())
 }
 
-/// Get the domains from [`SetupVarsEntry::ApiExcludeClients`] in lowercase.
+/// Get the clients from [`SetupVarsEntry::ApiExcludeClients`] in lowercase.
 ///
 /// [`SetupVarsEntry::ApiExcludeClients`]:
 /// ../../../settings/entries/enum.SetupVarsEntry.html#variant.ApiExcludeClients

--- a/src/routes/stats/database/mod.rs
+++ b/src/routes/stats/database/mod.rs
@@ -8,7 +8,8 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
+mod over_time_clients_db;
 mod over_time_history_db;
 mod summary_db;
 
-pub use self::{over_time_history_db::*, summary_db::*};
+pub use self::{over_time_clients_db::*, over_time_history_db::*, summary_db::*};

--- a/src/routes/stats/database/mod.rs
+++ b/src/routes/stats/database/mod.rs
@@ -14,4 +14,7 @@ mod query_types_db;
 mod summary_db;
 mod upstreams_db;
 
-pub use self::{over_time_clients_db::*, over_time_history_db::*, query_types_db::*, summary_db::*, upstreams_db::*};
+pub use self::{
+    over_time_clients_db::*, over_time_history_db::*, query_types_db::*, summary_db::*,
+    upstreams_db::*
+};

--- a/src/routes/stats/database/over_time_clients_db.rs
+++ b/src/routes/stats/database/over_time_clients_db.rs
@@ -1,0 +1,241 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// Clients Over Time Database Endpoint
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use crate::{
+    databases::ftl::FtlDatabase,
+    ftl::ClientReply,
+    routes::{
+        auth::User,
+        stats::{
+            database::over_time_history_db::align_from_until,
+            over_time_clients::{OverTimeClientItem, OverTimeClients}
+        }
+    },
+    settings::ValueType,
+    util::{reply_data, Error, ErrorKind, Reply}
+};
+use diesel::{dsl::sql, prelude::*, sql_types::BigInt, SqliteConnection};
+use failure::ResultExt;
+use std::collections::HashMap;
+
+/// Get the clients queries over time data from the database
+#[get("/stats/database/overTime/clients?<from>&<until>&<interval>")]
+pub fn over_time_clients_db(
+    from: u64,
+    until: u64,
+    interval: Option<usize>,
+    _auth: User,
+    db: FtlDatabase
+) -> Reply {
+    reply_data(over_time_clients_db_impl(
+        from,
+        until,
+        interval.unwrap_or(600),
+        &db as &SqliteConnection
+    )?)
+}
+
+/// Get the clients queries over time data from the database
+fn over_time_clients_db_impl(
+    from: u64,
+    until: u64,
+    interval: usize,
+    db: &SqliteConnection
+) -> Result<OverTimeClients, Error> {
+    let (from, until) = align_from_until(from, until, interval as u64)?;
+
+    // Load the clients (names or IP addresses)
+    let client_identifiers = get_client_identifiers(from, until, db)?;
+
+    // Build the timestamp -> client query data map
+    let mut over_time_data: HashMap<u64, Vec<usize>> = (from..until)
+        .step_by(interval)
+        .map(|timestamp| (timestamp, vec![0; client_identifiers.len()]))
+        .collect();
+
+    for (client_index, client_identifier) in client_identifiers.iter().enumerate() {
+        // For each client, get the overTime data
+        let client_over_time = get_client_over_time(from, until, interval, client_identifier, db)?;
+
+        // Add the client's data to the overTime map
+        for (timestamp, value) in client_over_time {
+            let client_data = over_time_data.get_mut(&(timestamp as u64)).unwrap();
+            client_data[client_index] = value as usize;
+        }
+    }
+
+    // Convert the overTime data into the output format
+    let mut over_time: Vec<OverTimeClientItem> = over_time_data
+        .into_iter()
+        .map(|(timestamp, data)| OverTimeClientItem {
+            // Display the timestamps as centered in the overTime slot interval
+            timestamp: timestamp + (interval / 2) as u64,
+            data
+        })
+        .collect();
+
+    // Make sure we return the overTime data in sorted order (by timestamp)
+    over_time.sort();
+
+    // Convert the client identifiers into the output format
+    let clients = client_identifiers
+        .into_iter()
+        .map(|client_identifier| {
+            if ValueType::Ipv4.is_valid(&client_identifier)
+                || ValueType::Ipv6.is_valid(&client_identifier)
+            {
+                // If the identifier is an IP address, use it as the client IP
+                ClientReply {
+                    name: "".to_owned(),
+                    ip: client_identifier
+                }
+            } else {
+                // If the identifier is not an IP address, use it as the name
+                ClientReply {
+                    name: client_identifier,
+                    ip: "".to_owned()
+                }
+            }
+        })
+        .collect();
+
+    Ok(OverTimeClients { over_time, clients })
+}
+
+/// Get clients which made queries during the interval. The values may be either
+/// hostnames or IP addresses
+fn get_client_identifiers(
+    from: u64,
+    until: u64,
+    db: &SqliteConnection
+) -> Result<Vec<String>, Error> {
+    use crate::databases::ftl::queries::dsl::*;
+
+    Ok(queries
+        .select(client)
+        .distinct()
+        .filter(timestamp.ge(from as i32))
+        .filter(timestamp.lt(until as i32))
+        .load(db)
+        .context(ErrorKind::FtlDatabase)?)
+}
+
+/// Get the overTime data for the client in the specified interval
+fn get_client_over_time(
+    from: u64,
+    until: u64,
+    interval: usize,
+    client_identifier: &str,
+    db: &SqliteConnection
+) -> Result<HashMap<i32, i64>, Error> {
+    use crate::databases::ftl::queries::dsl::*;
+
+    // SQL snippet for calculating the interval timestamp of the query
+    let interval_sql = sql(&format!(
+        "(timestamp / {interval}) * {interval}",
+        interval = interval
+    ));
+
+    // Create SQL query
+    let sql_query = queries
+        .select((&interval_sql, sql::<BigInt>("COUNT(*)")))
+        .filter(client.eq(client_identifier))
+        .filter(timestamp.ge(from as i32))
+        .filter(timestamp.lt(until as i32))
+        .group_by(&interval_sql);
+
+    // Execute SQL query
+    Ok(sql_query
+        .load(&db as &SqliteConnection)
+        .context(ErrorKind::FtlDatabase)?
+        // Convert to HashMap
+        .into_iter()
+        .collect())
+}
+
+#[cfg(test)]
+mod test {
+    use super::{get_client_identifiers, get_client_over_time, over_time_clients_db_impl};
+    use crate::{
+        databases::ftl::connect_to_test_db,
+        ftl::ClientReply,
+        routes::stats::over_time_clients::{OverTimeClientItem, OverTimeClients}
+    };
+    use std::collections::HashMap;
+
+    const FROM_TIMESTAMP: u64 = 164_400;
+    const UNTIL_TIMESTAMP: u64 = 165_600;
+    const INTERVAL: usize = 600;
+
+    /// Verify the over time data is retrieved correctly
+    #[test]
+    fn over_time_clients_impl() {
+        let expected = OverTimeClients {
+            clients: vec![
+                ClientReply {
+                    name: "".to_owned(),
+                    ip: "127.0.0.1".to_owned()
+                },
+                ClientReply {
+                    name: "".to_owned(),
+                    ip: "10.1.1.1".to_owned()
+                },
+            ],
+            over_time: vec![
+                OverTimeClientItem {
+                    timestamp: 164_700,
+                    data: vec![25, 1]
+                },
+                OverTimeClientItem {
+                    timestamp: 165_300,
+                    data: vec![7, 0]
+                },
+                OverTimeClientItem {
+                    timestamp: 165_900,
+                    data: vec![0, 0]
+                },
+            ]
+        };
+
+        let db = connect_to_test_db();
+        let actual =
+            over_time_clients_db_impl(FROM_TIMESTAMP, UNTIL_TIMESTAMP, INTERVAL, &db).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    /// The client identifiers stored in the database are all retrieved for a
+    /// specified interval
+    #[test]
+    fn client_identifiers() {
+        let expected = vec!["127.0.0.1".to_owned(), "10.1.1.1".to_owned()];
+
+        let db = connect_to_test_db();
+        let actual = get_client_identifiers(FROM_TIMESTAMP, UNTIL_TIMESTAMP, &db).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    /// The client-specific overTime data is retrieved correctly for a specified
+    /// time interval
+    #[test]
+    fn client_over_time() {
+        let mut expected: HashMap<i32, i64> = HashMap::new();
+        expected.insert(164_400, 25);
+        expected.insert(165_000, 7);
+
+        let db = connect_to_test_db();
+        let actual =
+            get_client_over_time(FROM_TIMESTAMP, UNTIL_TIMESTAMP, INTERVAL, "127.0.0.1", &db)
+                .unwrap();
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/routes/stats/history/filters/exclude_clients.rs
+++ b/src/routes/stats/history/filters/exclude_clients.rs
@@ -26,11 +26,12 @@ pub fn filter_excluded_clients<'a>(
     ftl_lock: &ShmLockGuard<'a>
 ) -> Result<Box<dyn Iterator<Item = &'a FtlQuery> + 'a>, Error> {
     // Get the excluded clients list
-    let excluded_clients = SetupVarsEntry::ApiExcludeClients.read(env)?.to_lowercase();
-    let excluded_clients: HashSet<&str> = excluded_clients
-        .split(',')
-        .filter(|s| !s.is_empty())
+    let excluded_clients: Vec<String> = SetupVarsEntry::ApiExcludeClients
+        .read_list(env)?
+        .into_iter()
+        .map(|s| s.to_lowercase())
         .collect();
+    let excluded_clients: HashSet<&str> = excluded_clients.iter().map(String::as_str).collect();
 
     // End early if there are no excluded clients
     if excluded_clients.is_empty() {
@@ -77,11 +78,10 @@ pub fn filter_excluded_clients_db<'a>(
     use self::queries::dsl::*;
 
     // Get the excluded clients list
-    let excluded_clients = SetupVarsEntry::ApiExcludeClients.read(env)?.to_lowercase();
-    let excluded_clients: HashSet<String> = excluded_clients
-        .split(',')
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_owned())
+    let excluded_clients: HashSet<String> = SetupVarsEntry::ApiExcludeClients
+        .read_list(env)?
+        .into_iter()
+        .map(|s| s.to_lowercase())
         .collect();
 
     if excluded_clients.is_empty() {

--- a/src/routes/stats/history/filters/exclude_domains.rs
+++ b/src/routes/stats/history/filters/exclude_domains.rs
@@ -26,11 +26,12 @@ pub fn filter_excluded_domains<'a>(
     ftl_lock: &ShmLockGuard<'a>
 ) -> Result<Box<dyn Iterator<Item = &'a FtlQuery> + 'a>, Error> {
     // Get the excluded domains list
-    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
-    let excluded_domains: HashSet<&str> = excluded_domains
-        .split(',')
-        .filter(|s| !s.is_empty())
+    let excluded_domains: Vec<String> = SetupVarsEntry::ApiExcludeDomains
+        .read_list(env)?
+        .into_iter()
+        .map(|s| s.to_lowercase())
         .collect();
+    let excluded_domains: HashSet<&str> = excluded_domains.iter().map(String::as_str).collect();
 
     // End early if there are no excluded domains
     if excluded_domains.is_empty() {
@@ -74,11 +75,10 @@ pub fn filter_excluded_domains_db<'a>(
     use self::queries::dsl::*;
 
     // Get the excluded domains list
-    let excluded_domains = SetupVarsEntry::ApiExcludeDomains.read(env)?.to_lowercase();
-    let excluded_domains: HashSet<String> = excluded_domains
-        .split(',')
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_owned())
+    let excluded_domains: HashSet<String> = SetupVarsEntry::ApiExcludeDomains
+        .read_list(env)?
+        .into_iter()
+        .map(|s| s.to_lowercase())
         .collect();
 
     if excluded_domains.is_empty() {

--- a/src/routes/stats/over_time_clients.rs
+++ b/src/routes/stats/over_time_clients.rs
@@ -10,19 +10,18 @@
 
 use crate::{
     env::Env,
-    ftl::{FtlClient, FtlMemory},
+    ftl::{ClientReply, FtlMemory},
     routes::{
         auth::User,
-        stats::common::{
-            get_current_over_time_slot, remove_excluded_clients, remove_hidden_clients
+        stats::{
+            clients::{filter_ftl_clients, ClientParams},
+            common::get_current_over_time_slot
         }
     },
     settings::{ConfigEntry, FtlConfEntry, FtlPrivacyLevel},
     util::{reply_data, Reply}
 };
 use rocket::State;
-use rocket_contrib::json::JsonValue;
-use std::collections::HashMap;
 
 /// Get the client queries over time
 #[get("/stats/overTime/clients")]
@@ -31,51 +30,38 @@ pub fn over_time_clients(_auth: User, ftl_memory: State<FtlMemory>, env: State<E
     if FtlConfEntry::PrivacyLevel.read_as::<FtlPrivacyLevel>(&env)?
         >= FtlPrivacyLevel::HideDomainsAndClients
     {
-        return reply_data(json!({
-            "over_time": [],
-            "clients": []
-        }));
+        return reply_data(OverTimeClients {
+            over_time: Vec::new(),
+            clients: Vec::new()
+        });
     }
 
     // Load FTL shared memory
     let lock = ftl_memory.lock()?;
-    let counters = ftl_memory.counters(&lock)?;
     let strings = ftl_memory.strings(&lock)?;
     let over_time = ftl_memory.over_time(&lock)?;
-    let clients = ftl_memory.clients(&lock)?;
+    let ftl_clients = ftl_memory.clients(&lock)?;
 
-    // Store the client IDs (indexes), even after going through filters
-    let mut client_ids = HashMap::new();
-
-    // Get the clients we will be returning overTime data of
-    let mut clients: Vec<&FtlClient> = clients
-        .iter()
-        .take(counters.total_clients as usize)
-        // Enumerate so the client ID can be stored
-        .enumerate()
-        .map(|(i, client)| {
-            client_ids.insert(client, i);
-
-            // After this, we don't need the index in this iterator
-            client
-        })
-        .collect();
-
-    // Ignore hidden and excluded clients
-    remove_hidden_clients(&mut clients, &strings);
-    remove_excluded_clients(&mut clients, &env, &strings)?;
+    // Filter out clients which should not be considered
+    let clients = filter_ftl_clients(
+        &ftl_memory,
+        &lock,
+        &ftl_clients,
+        &env,
+        ClientParams::default()
+    )?;
 
     // Get the valid over time slots (Skip while the slots are empty).
     // Then, combine with the client overTime data to get the final overTime
     // output.
-    let over_time: Vec<JsonValue> = over_time
+    let over_time: Vec<OverTimeClientItem> = over_time
         .iter()
         // Take all of the slots including the current slot
         .take(get_current_over_time_slot(&over_time) + 1)
         .enumerate()
         // Skip the overTime slots without any data
         .skip_while(|(_, time)| {
-            (time.total_queries <= 0 && time.blocked_queries <= 0)
+            time.total_queries <= 0 && time.blocked_queries <= 0
         })
         .map(|(i, time)| {
             // Get the client data for this time slot
@@ -85,31 +71,35 @@ pub fn over_time_clients(_auth: User, ftl_memory: State<FtlMemory>, env: State<E
                 .map(|client| *client.over_time.get(i).unwrap_or(&0) as usize)
                 .collect();
 
-            json!({
-                "timestamp": time.timestamp,
-                "data": data
-            })
+            OverTimeClientItem {
+                timestamp: time.timestamp as u64,
+                data
+            }
         })
         .collect();
 
     // Convert clients into the output format
-    let clients: Vec<JsonValue> = clients
+    let clients: Vec<ClientReply> = clients
         .into_iter()
-        .map(|client| {
-            let name = client.get_name(&strings).unwrap_or_default();
-            let ip = client.get_ip(&strings);
-
-            json!({
-                "name": name,
-                "ip": ip
-            })
-        })
+        .map(|client| client.as_reply(&strings))
         .collect();
 
-    reply_data(json!({
-        "over_time": over_time,
-        "clients": clients
-    }))
+    reply_data(OverTimeClients { over_time, clients })
+}
+
+/// Represents an overTime client item, which holds time and client data for an
+/// overTime interval
+#[derive(Serialize)]
+pub struct OverTimeClientItem {
+    pub timestamp: u64,
+    pub data: Vec<usize>
+}
+
+/// Represents the reply format for the overTime clients endpoint
+#[derive(Serialize)]
+pub struct OverTimeClients {
+    pub over_time: Vec<OverTimeClientItem>,
+    pub clients: Vec<ClientReply>
 }
 
 #[cfg(test)]
@@ -140,15 +130,15 @@ mod test {
                 FtlClient::new(1, 0, 3, None).with_over_time(vec![0, 1, 0, 0]),
                 FtlClient::new(1, 0, 4, Some(5)).with_over_time(vec![0, 1, 0, 0]),
                 FtlClient::new(1, 0, 6, None).with_over_time(vec![0, 0, 1, 0]),
-                FtlClient::new(0, 0, 7, None).with_over_time(vec![0, 0, 1, 0]),
-                FtlClient::new(0, 0, 8, None).with_over_time(vec![0, 0, 0, 1]),
+                FtlClient::new(1, 0, 7, None).with_over_time(vec![0, 0, 1, 0]),
+                FtlClient::new(0, 0, 8, None).with_over_time(vec![0, 0, 0, 0]),
             ],
             domains: Vec::new(),
             over_time: vec![
                 FtlOverTime::new(0, 0, 0, 0, 0, [0; 7]),
-                FtlOverTime::new(1, 3, 0, 2, 1, [0; 7]),
-                FtlOverTime::new(2, 2, 2, 0, 0, [0; 7]),
-                FtlOverTime::new(3, 1, 1, 1, 0, [0; 7]),
+                FtlOverTime::new(1, 2, 2, 0, 0, [0; 7]),
+                FtlOverTime::new(2, 3, 0, 2, 1, [0; 7]),
+                FtlOverTime::new(3, 0, 0, 1, 0, [0; 7]),
             ],
             strings,
             upstreams: Vec::new(),
@@ -161,8 +151,9 @@ mod test {
         }
     }
 
-    /// Default params will show overTime data from all non-hidden and
-    /// non-excluded clients, and will skip overTime slots with no queries.
+    /// Default params will show overTime data from all non-hidden, active, and
+    /// non-excluded clients, and will initially skip overTime slots with no
+    /// queries.
     #[test]
     fn default_params() {
         TestBuilder::new()

--- a/src/routes/stats/over_time_clients.rs
+++ b/src/routes/stats/over_time_clients.rs
@@ -22,6 +22,7 @@ use crate::{
     util::{reply_data, Reply}
 };
 use rocket::State;
+use std::cmp::Ordering;
 
 /// Get the client queries over time
 #[get("/stats/overTime/clients")]
@@ -89,14 +90,32 @@ pub fn over_time_clients(_auth: User, ftl_memory: State<FtlMemory>, env: State<E
 
 /// Represents an overTime client item, which holds time and client data for an
 /// overTime interval
-#[derive(Serialize)]
+#[derive(Serialize, PartialEq, Eq)]
+#[cfg_attr(test, derive(Debug))]
 pub struct OverTimeClientItem {
     pub timestamp: u64,
     pub data: Vec<usize>
 }
 
+impl PartialOrd for OverTimeClientItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(
+            self.timestamp
+                .cmp(&other.timestamp)
+                .then(self.data.cmp(&other.data))
+        )
+    }
+}
+
+impl Ord for OverTimeClientItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
 /// Represents the reply format for the overTime clients endpoint
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct OverTimeClients {
     pub over_time: Vec<OverTimeClientItem>,
     pub clients: Vec<ClientReply>

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -57,6 +57,16 @@ pub trait ConfigEntry {
             .map_err(Error::from)
     }
 
+    /// Try to read the value as a comma-separated list
+    fn read_list(&self, env: &Env) -> Result<Vec<String>, Error> {
+        Ok(self
+            .read(env)?
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(ToOwned::to_owned)
+            .collect())
+    }
+
     /// Read this setting from the config file it appears in.
     /// If the setting is not found, its default value is returned.
     fn read(&self, env: &Env) -> Result<String, Error> {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -160,6 +160,7 @@ fn setup(
             stats::over_time_history,
             stats::over_time_clients,
             stats::database::get_summary_db,
+            stats::database::over_time_clients_db,
             stats::database::over_time_history_db,
             dns::get_whitelist,
             dns::get_blacklist,


### PR DESCRIPTION
Given a from timestamp, until timestamp, and optional interval (in seconds), this endpoint will return data for the over time clients graph. The response format is the same as `/stats/overTime/clients`.

The previous over time clients endpoint now uses a shared `OverTimeClients` struct, and there are a few more shared structs.

The regular over time clients endpoint has been refactored a bit, and now shares some logic with the `/stats/clients` endpoint.

See #88 