### PR TITLE
Add /stats/database/query_types

### DIFF
--- a/src/ftl/memory_model/counters.rs
+++ b/src/ftl/memory_model/counters.rs
@@ -97,4 +97,9 @@ impl FtlQueryType {
             _ => None
         }
     }
+
+    /// Get the name of the query type
+    pub fn get_name(&self) -> String {
+        format!("{:?}", self)
+    }
 }

--- a/src/ftl/memory_model/counters.rs
+++ b/src/ftl/memory_model/counters.rs
@@ -99,7 +99,7 @@ impl FtlQueryType {
     }
 
     /// Get the name of the query type
-    pub fn get_name(&self) -> String {
+    pub fn get_name(self) -> String {
         format!("{:?}", self)
     }
 }

--- a/src/routes/stats/database/mod.rs
+++ b/src/routes/stats/database/mod.rs
@@ -9,6 +9,7 @@
 // Please see LICENSE file for your rights under this license.
 
 mod over_time_history_db;
+mod query_types_db;
 mod summary_db;
 
-pub use self::{over_time_history_db::*, summary_db::*};
+pub use self::{over_time_history_db::*, query_types_db::*, summary_db::*};

--- a/src/routes/stats/database/query_types_db.rs
+++ b/src/routes/stats/database/query_types_db.rs
@@ -1,0 +1,111 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// Query Types Endpoint - DB Version
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use crate::{
+    databases::ftl::FtlDatabase,
+    ftl::FtlQueryType,
+    routes::{auth::User, stats::query_types::QueryTypeReply},
+    util::{reply_data, Error, ErrorKind, Reply}
+};
+use diesel::{dsl::sql, prelude::*, sql_types::BigInt, sqlite::SqliteConnection};
+use failure::ResultExt;
+use std::collections::HashMap;
+
+/// Get query type counts from the database
+#[get("/stats/database/query_types?<from>&<until>")]
+pub fn query_types_db(from: u64, until: u64, _auth: User, db: FtlDatabase) -> Reply {
+    reply_data(query_types_db_impl(from, until, &db as &SqliteConnection)?)
+}
+
+/// Get query type counts from the database
+fn query_types_db_impl(
+    from: u64,
+    until: u64,
+    db: &SqliteConnection
+) -> Result<Vec<QueryTypeReply>, Error> {
+    let query_types = get_query_type_counts(db, from, until)?;
+
+    Ok(FtlQueryType::variants()
+        .iter()
+        .map(|variant| QueryTypeReply {
+            name: variant.get_name(),
+            count: query_types[variant]
+        })
+        .collect())
+}
+
+/// Get the number of queries with each query type in the specified time range
+pub fn get_query_type_counts(
+    db: &SqliteConnection,
+    from: u64,
+    until: u64
+) -> Result<HashMap<FtlQueryType, usize>, Error> {
+    use crate::databases::ftl::queries::dsl::*;
+
+    let mut counts: HashMap<FtlQueryType, usize> = queries
+        // Select the query types and their counts.
+        // The raw SQL is used due to a limitation of Diesel, in that it doesn't
+        // have full support for mixing aggregate and non-aggregate data when
+        // using group_by. See https://github.com/diesel-rs/diesel/issues/1781
+        .select((query_type, sql::<BigInt>("COUNT(*)")))
+        // Search in the specified time interval
+        .filter(timestamp.le(until as i32).and(timestamp.ge(from as i32)))
+        // Group the results by query type
+        .group_by(query_type)
+        // Execute the query
+        .get_results::<(i32, i64)>(db)
+        // Add error context and check for errors
+        .context(ErrorKind::FtlDatabase)?
+        // Turn the resulting Vec into an iterator
+        .into_iter()
+        // Map the values into (FtlQueryType, usize)
+        .map(|(q_type, count)| {
+            (FtlQueryType::from_number(q_type as isize).unwrap(), count as usize)
+        })
+        // Turn the iterator into a HashMap
+        .collect();
+
+    // Fill in the rest of the query types not found in the database
+    for q_type in FtlQueryType::variants() {
+        if !counts.contains_key(q_type) {
+            counts.insert(*q_type, 0);
+        }
+    }
+
+    Ok(counts)
+}
+
+#[cfg(test)]
+mod test {
+    use super::get_query_type_counts;
+    use crate::{databases::ftl::connect_to_test_db, ftl::FtlQueryType};
+    use std::collections::HashMap;
+
+    const FROM_TIMESTAMP: u64 = 0;
+    const UNTIL_TIMESTAMP: u64 = 177_180;
+
+    /// Verify the query type counts are accurate
+    #[test]
+    fn query_type_counts() {
+        let mut expected = HashMap::new();
+        expected.insert(FtlQueryType::A, 36);
+        expected.insert(FtlQueryType::AAAA, 35);
+        expected.insert(FtlQueryType::ANY, 0);
+        expected.insert(FtlQueryType::SRV, 0);
+        expected.insert(FtlQueryType::SOA, 0);
+        expected.insert(FtlQueryType::PTR, 23);
+        expected.insert(FtlQueryType::TXT, 0);
+
+        let db = connect_to_test_db();
+        let actual = get_query_type_counts(&db, FROM_TIMESTAMP, UNTIL_TIMESTAMP).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/routes/stats/database/summary_db.rs
+++ b/src/routes/stats/database/summary_db.rs
@@ -14,7 +14,10 @@ use crate::{
     ftl::{FtlQueryStatus, FtlQueryType, BLOCKED_STATUSES},
     routes::{
         auth::User,
-        stats::summary::{ReplyTypes, Summary, TotalQueries}
+        stats::{
+            database::get_query_type_counts,
+            summary::{ReplyTypes, Summary, TotalQueries}
+        }
     },
     settings::{ConfigEntry, SetupVarsEntry},
     util::{reply_data, Error, ErrorKind, Reply}
@@ -22,7 +25,6 @@ use crate::{
 use diesel::prelude::*;
 use failure::ResultExt;
 use rocket::State;
-use std::collections::HashMap;
 
 /// Get summary data from database
 #[get("/stats/database/summary?<from>&<until>")]
@@ -30,14 +32,15 @@ pub fn get_summary_db(
     from: u64,
     until: u64,
     _auth: User,
-    ftl_database: FtlDatabase,
+    db: FtlDatabase,
     env: State<Env>
 ) -> Reply {
-    // Cast the database connection to &SqliteConnection to make using it easier
-    // (only need to cast once, here)
-    let db = &ftl_database as &SqliteConnection;
-
-    reply_data(get_summary_impl(from, until, db, &env)?)
+    reply_data(get_summary_impl(
+        from,
+        until,
+        &db as &SqliteConnection,
+        &env
+    )?)
 }
 
 /// Implementation of [`get_summary_db`]
@@ -109,48 +112,6 @@ fn get_summary_impl(
     })
 }
 
-/// Get the number of queries with each query type in the specified time range
-fn get_query_type_counts(
-    db: &SqliteConnection,
-    from: u64,
-    until: u64
-) -> Result<HashMap<FtlQueryType, usize>, Error> {
-    use crate::databases::ftl::queries::dsl::*;
-    use diesel::{dsl::sql, sql_types::BigInt};
-
-    let mut counts: HashMap<FtlQueryType, usize> = queries
-        // Select the query types and their counts.
-        // The raw SQL is used due to a limitation of Diesel, in that it doesn't
-        // have full support for mixing aggregate and non-aggregate data when
-        // using group_by. See https://github.com/diesel-rs/diesel/issues/1781
-        .select((query_type, sql::<BigInt>("COUNT(*)")))
-        // Search in the specified time interval
-        .filter(timestamp.le(until as i32).and(timestamp.ge(from as i32)))
-        // Group the results by query type
-        .group_by(query_type)
-        // Execute the query
-        .get_results::<(i32, i64)>(db)
-        // Add error context and check for errors
-        .context(ErrorKind::FtlDatabase)?
-        // Turn the resulting Vec into an iterator
-        .into_iter()
-        // Map the values into (FtlQueryType, usize)
-        .map(|(q_type, count)| {
-            (FtlQueryType::from_number(q_type as isize).unwrap(), count as usize)
-        })
-        // Turn the iterator into a HashMap
-        .collect();
-
-    // Fill in the rest of the query types not found in the database
-    for q_type in FtlQueryType::variants() {
-        if !counts.contains_key(q_type) {
-            counts.insert(*q_type, 0);
-        }
-    }
-
-    Ok(counts)
-}
-
 /// Get the number of blocked queries in the specified time range
 fn get_blocked_query_count(db: &SqliteConnection, from: u64, until: u64) -> Result<usize, Error> {
     use crate::databases::ftl::queries::dsl::*;
@@ -204,13 +165,12 @@ fn get_query_status_count(
 #[cfg(test)]
 mod test {
     use super::{
-        get_blocked_query_count, get_query_status_count, get_query_type_counts, get_summary_impl,
-        get_unique_domain_count
+        get_blocked_query_count, get_query_status_count, get_summary_impl, get_unique_domain_count
     };
     use crate::{
         databases::ftl::connect_to_test_db,
         env::{Config, Env},
-        ftl::{FtlQueryStatus, FtlQueryType},
+        ftl::FtlQueryStatus,
         routes::stats::summary::{ReplyTypes, Summary, TotalQueries}
     };
     use std::collections::HashMap;
@@ -254,24 +214,6 @@ mod test {
         let actual_summary = get_summary_impl(FROM_TIMESTAMP, UNTIL_TIMESTAMP, &db, &env).unwrap();
 
         assert_eq!(actual_summary, expected_summary);
-    }
-
-    /// Verify the query type counts are accurate
-    #[test]
-    fn query_type_counts() {
-        let mut expected = HashMap::new();
-        expected.insert(FtlQueryType::A, 36);
-        expected.insert(FtlQueryType::AAAA, 35);
-        expected.insert(FtlQueryType::ANY, 0);
-        expected.insert(FtlQueryType::SRV, 0);
-        expected.insert(FtlQueryType::SOA, 0);
-        expected.insert(FtlQueryType::PTR, 23);
-        expected.insert(FtlQueryType::TXT, 0);
-
-        let db = connect_to_test_db();
-        let actual = get_query_type_counts(&db, FROM_TIMESTAMP, UNTIL_TIMESTAMP).unwrap();
-
-        assert_eq!(actual, expected);
     }
 
     /// Verify the blocked query count is accurate

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -161,6 +161,7 @@ fn setup(
             stats::over_time_clients,
             stats::database::get_summary_db,
             stats::database::over_time_history_db,
+            stats::database::query_types_db,
             dns::get_whitelist,
             dns::get_blacklist,
             dns::get_regexlist,


### PR DESCRIPTION
The normal query types endpoint was refactored to use a reply struct. Logic for the database endpoint  is shared with summary_db, and now lives in query_types_db.rs.