### PR TITLE
Add /stats/database/top_domains

### DIFF
--- a/src/env/env_impl.rs
+++ b/src/env/env_impl.rs
@@ -15,14 +15,16 @@ use crate::{
 use failure::ResultExt;
 use std::{
     fs::{self, File, OpenOptions},
+    io::{BufRead, BufReader},
     os::unix::fs::OpenOptionsExt,
     path::Path
 };
 
 #[cfg(test)]
-use std::collections::HashMap;
-#[cfg(test)]
-use std::io::{Read, Write};
+use std::{
+    collections::HashMap,
+    io::{Read, Write}
+};
 #[cfg(test)]
 use tempfile::{tempfile, NamedTempFile};
 
@@ -83,6 +85,13 @@ impl Env {
                 None => tempfile().context(ErrorKind::Unknown).map_err(Error::from)
             }
         }
+    }
+
+    /// Open a file and read its lines. This uses a `BufReader` under the hood
+    /// and skips lines with errors (invalid UTF-8).
+    pub fn read_file_lines(&self, file: PiholeFile) -> Result<Vec<String>, Error> {
+        let reader = BufReader::new(self.read_file(file)?);
+        Ok(reader.lines().filter_map(Result::ok).collect())
     }
 
     /// Open a file for writing. If `append` is false, the file will be

--- a/src/routes/dns/list.rs
+++ b/src/routes/dns/list.rs
@@ -14,7 +14,7 @@ use crate::{
     util::{Error, ErrorKind}
 };
 use failure::ResultExt;
-use std::io::{prelude::*, BufReader, BufWriter};
+use std::io::{prelude::*, BufWriter};
 
 pub enum List {
     White,
@@ -42,8 +42,8 @@ impl List {
 
     /// Read in the domains from the list
     pub fn get(&self, env: &Env) -> Result<Vec<String>, Error> {
-        let file = match env.read_file(self.file()) {
-            Ok(f) => f,
+        let domains = match env.read_file_lines(self.file()) {
+            Ok(domains) => domains,
             Err(e) => {
                 if e.kind() == ErrorKind::NotFound {
                     // If the file is not found, then the list is empty
@@ -54,10 +54,9 @@ impl List {
             }
         };
 
-        Ok(BufReader::new(file)
-            .lines()
-            .filter_map(|line| line.ok())
-            .filter(|line| !line.is_empty())
+        Ok(domains
+            .into_iter()
+            .filter(|domain| !domain.is_empty())
             .collect())
     }
 

--- a/src/routes/stats/database/mod.rs
+++ b/src/routes/stats/database/mod.rs
@@ -12,9 +12,10 @@ mod over_time_clients_db;
 mod over_time_history_db;
 mod query_types_db;
 mod summary_db;
+mod top_domains_db;
 mod upstreams_db;
 
 pub use self::{
     over_time_clients_db::*, over_time_history_db::*, query_types_db::*, summary_db::*,
-    upstreams_db::*
+    top_domains_db::*, upstreams_db::*
 };

--- a/src/routes/stats/database/over_time_clients_db.rs
+++ b/src/routes/stats/database/over_time_clients_db.rs
@@ -167,7 +167,7 @@ fn get_client_over_time(
 
     // Execute SQL query
     Ok(sql_query
-        .load(&db as &SqliteConnection)
+        .load(db)
         .context(ErrorKind::FtlDatabase)?
         // Convert to HashMap
         .into_iter()

--- a/src/routes/stats/database/top_domains_db.rs
+++ b/src/routes/stats/database/top_domains_db.rs
@@ -148,7 +148,7 @@ fn execute_top_domains_query(
         .select((domain, sql::<BigInt>("COUNT(*)")))
         // Only consider queries in the time interval
         .filter(timestamp.ge(from as i32))
-        .filter(timestamp.lt(until as i32))
+        .filter(timestamp.le(until as i32))
         // Filter out ignored domains
         .filter(domain.ne_all(ignored_domains))
         // Group queries by domain
@@ -160,9 +160,9 @@ fn execute_top_domains_query(
 
     // Set the sort order
     let db_query = if ascending {
-        db_query.order(sql::<BigInt>("COUNT(*)").asc())
+        db_query.order((sql::<BigInt>("COUNT(*)").asc(), domain))
     } else {
-        db_query.order(sql::<BigInt>("COUNT(*)").desc())
+        db_query.order((sql::<BigInt>("COUNT(*)").desc(), domain))
     };
 
     // Filter by status

--- a/src/routes/stats/database/top_domains_db.rs
+++ b/src/routes/stats/database/top_domains_db.rs
@@ -1,0 +1,179 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// Top Domains/Blocked Endpoints - DB Version
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use crate::{
+    databases::ftl::FtlDatabase,
+    env::{Env, PiholeFile},
+    ftl::BLOCKED_STATUSES,
+    routes::{
+        auth::User,
+        stats::{
+            check_privacy_level_top_domains, check_query_log_show_top_domains,
+            common::{get_excluded_domains, get_hidden_domain},
+            database::{
+                query_types_db::get_query_type_counts, summary_db::get_blocked_query_count
+            },
+            top_domains::{TopDomainItemReply, TopDomainParams, TopDomainsReply}
+        }
+    },
+    util::{reply_data, Error, ErrorKind, Reply}
+};
+use diesel::{dsl::sql, prelude::*, sql_types::BigInt, sqlite::SqliteConnection};
+use failure::ResultExt;
+use rocket::{request::Form, State};
+
+/// Return the top domains
+#[get("/stats/database/top_domains?<from>&<until>&<params..>")]
+pub fn top_domains_db(
+    _auth: User,
+    env: State<Env>,
+    db: FtlDatabase,
+    from: u64,
+    until: u64,
+    params: Form<TopDomainParams>
+) -> Reply {
+    reply_data(top_domains_db_impl(
+        &env,
+        &db as &SqliteConnection,
+        from,
+        until,
+        params.into_inner()
+    )?)
+}
+
+/// Return the top domains
+fn top_domains_db_impl(
+    env: &Env,
+    db: &SqliteConnection,
+    from: u64,
+    until: u64,
+    params: TopDomainParams
+) -> Result<TopDomainsReply, Error> {
+    // Resolve the parameters
+    let limit = params.limit.unwrap_or(10);
+    let audit = params.audit.unwrap_or(false);
+    let ascending = params.ascending.unwrap_or(false);
+    let blocked = params.blocked.unwrap_or(false);
+
+    // Check if we are allowed to share the top domains
+    if let Some(reply) = check_query_log_show_top_domains(env, blocked)? {
+        // We can not share any of the domains, so use the reply returned by the
+        // function
+        return Ok(reply);
+    }
+
+    let total_count = if blocked {
+        get_blocked_query_count(db, from, until)?
+    } else {
+        // Total query count is the sum of all query type counts
+        get_query_type_counts(db, from, until)?.values().sum()
+    } as usize;
+
+    // Check if the domain details are private
+    if let Some(reply) = check_privacy_level_top_domains(env, blocked, total_count)? {
+        // We can not share any of the domains, so use the reply returned by the
+        // function
+        return Ok(reply);
+    }
+
+    // Find domains which should not be considered
+    let ignored_domains = get_ignored_domains(env, audit)?;
+
+    // Fetch the top domains and map into the reply structure
+    let top_domains: Vec<TopDomainItemReply> =
+        execute_top_domains_query(db, from, until, ignored_domains, blocked, ascending, limit)?
+            .into_iter()
+            .map(|(domain, count)| TopDomainItemReply {
+                domain,
+                count: count as usize
+            })
+            .collect();
+
+    // Output format changes when getting top blocked domains
+    if blocked {
+        Ok(TopDomainsReply {
+            top_domains,
+            total_queries: None,
+            blocked_queries: Some(total_count)
+        })
+    } else {
+        Ok(TopDomainsReply {
+            top_domains,
+            total_queries: Some(total_count),
+            blocked_queries: None
+        })
+    }
+}
+
+/// Get the list of domains to ignore. If the audit flag is true, audited
+/// domains are ignored (only show unaudited domains).
+fn get_ignored_domains(env: &Env, audit: bool) -> Result<Vec<String>, Error> {
+    // Ignore domains excluded via SetupVars
+    let mut ignored_domains = get_excluded_domains(env)?;
+
+    // Ignore the hidden domain (due to privacy level)
+    ignored_domains.push(get_hidden_domain().to_owned());
+
+    // If audit flag is true, only include unaudited domains
+    if audit {
+        ignored_domains.extend(env.read_file_lines(PiholeFile::AuditLog)?);
+    }
+
+    Ok(ignored_domains)
+}
+
+/// Create and execute the database query to retrieve the top domain details.
+/// The returned Vec contains each domain and its count, sorted and ordered
+/// according to the parameters.
+fn execute_top_domains_query(
+    db: &SqliteConnection,
+    from: u64,
+    until: u64,
+    ignored_domains: Vec<String>,
+    blocked: bool,
+    ascending: bool,
+    limit: usize
+) -> Result<Vec<(String, i64)>, Error> {
+    use crate::databases::ftl::queries::dsl::*;
+
+    // Create query
+    let db_query = queries
+        .select((domain, sql::<BigInt>("COUNT(*)")))
+        // Only consider queries in the time interval
+        .filter(timestamp.ge(from as i32))
+        .filter(timestamp.lt(until as i32))
+        // Filter out ignored domains
+        .filter(domain.ne_all(ignored_domains))
+        // Group queries by domain
+        .group_by(domain)
+        // Take into account limit
+        .limit(limit as i64)
+        // Box the query so we can conditionally modify it
+        .into_boxed();
+
+    // Set the sort order
+    let db_query = if ascending {
+        db_query.order(sql::<BigInt>("COUNT(*)").asc())
+    } else {
+        db_query.order(sql::<BigInt>("COUNT(*)").desc())
+    };
+
+    // Filter by status
+    let db_query = if blocked {
+        db_query.filter(status.eq_any(&BLOCKED_STATUSES))
+    } else {
+        db_query.filter(status.ne_all(&BLOCKED_STATUSES))
+    };
+
+    // Execute query
+    Ok(db_query
+        .load::<(String, i64)>(db)
+        .context(ErrorKind::FtlDatabase)?)
+}

--- a/src/routes/stats/top_domains.rs
+++ b/src/routes/stats/top_domains.rs
@@ -32,7 +32,7 @@ pub fn top_domains(
 }
 
 /// Represents the possible GET parameters for top (blocked) domains requests
-#[derive(FromForm)]
+#[derive(FromForm, Default)]
 pub struct TopDomainParams {
     pub limit: Option<usize>,
     pub audit: Option<bool>,
@@ -42,6 +42,7 @@ pub struct TopDomainParams {
 
 /// Represents the reply structure for top (blocked) domains
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct TopDomainsReply {
     pub top_domains: Vec<TopDomainItemReply>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -52,6 +53,7 @@ pub struct TopDomainsReply {
 
 /// Represents the reply structure for a top (blocked) domain item
 #[derive(Serialize)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct TopDomainItemReply {
     pub domain: String,
     pub count: usize

--- a/src/routes/stats/top_domains.rs
+++ b/src/routes/stats/top_domains.rs
@@ -19,7 +19,6 @@ use crate::{
     util::{reply_data, Error, Reply}
 };
 use rocket::{request::Form, State};
-use std::io::{BufRead, BufReader};
 
 /// Return the top domains
 #[get("/stats/top_domains?<params..>")]
@@ -141,9 +140,7 @@ fn get_top_domains(
 
     // If audit flag is true, only include unaudited domains
     if audit {
-        let audit_file = BufReader::new(env.read_file(PiholeFile::AuditLog)?);
-        let audited_domains: Vec<String> =
-            audit_file.lines().filter_map(|line| line.ok()).collect();
+        let audited_domains = env.read_file_lines(PiholeFile::AuditLog)?;
 
         // Get a vector of references to strings, to better compare with the domains
         let audited_domains: Vec<&str> = audited_domains.iter().map(String::as_str).collect();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -163,6 +163,7 @@ fn setup(
             stats::database::over_time_clients_db,
             stats::database::over_time_history_db,
             stats::database::query_types_db,
+            stats::database::top_domains_db,
             stats::database::upstreams_db,
             dns::get_whitelist,
             dns::get_blacklist,


### PR DESCRIPTION
The normal top domains endpoint has been refactored to use reply structs, which are shared with the database version. They share some more logic around permissions (privacy level and SetupVars settings) as well. Some functions are reused from summary_db, such as getting the number of blocked queries and total queries.

`Env::read_file_lines` has been added to simplify reading lines from a file.