### PR TITLE
Update task_scheduler to use 0.2.0 instead of fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,7 +574,7 @@ dependencies = [
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "shmem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "task_scheduler 0.1.0 (git+https://github.com/Mcat12/task_scheduler.git?branch=fix/mutable-api)",
+ "task_scheduler 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1035,8 +1035,8 @@ dependencies = [
 
 [[package]]
 name = "task_scheduler"
-version = "0.1.0"
-source = "git+https://github.com/Mcat12/task_scheduler.git?branch=fix/mutable-api#11a5d900903746196523be4036e7b11fe6e008bd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "tempfile"
@@ -1369,7 +1369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-"checksum task_scheduler 0.1.0 (git+https://github.com/Mcat12/task_scheduler.git?branch=fix/mutable-api)" = "<none>"
+"checksum task_scheduler 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023ced5b7293f7d605c6542c8f4710d9fa57be380de83f3195d73c9c3438fba7"
 "checksum tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "37daa55a7240c4931c84559f03b3cad7d19535840d1c4a0cc4e9b2fb0dcf70ff"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ shmem = "0.2.0"
 libc = "0.2.42"
 nix = "0.13"
 base64 = "0.10"
-task_scheduler = { git = "https://github.com/Mcat12/task_scheduler.git", branch = "fix/mutable-api" }
+task_scheduler = "0.2.0"
 
 [dependencies.rocket_contrib]
 version = "0.4"


### PR DESCRIPTION
The patch has been merged into the upstream crate: https://github.com/fuchsnj/task_scheduler/pull/2