### PR TITLE
RPM Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,43 @@ version: 2
           [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" "${BIN_NAME}.sha1" "${FTL_SECRET}"
           [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" pihole-api*.deb "${FTL_SECRET}"
           rm ./FTL-client
+      # Save the files necessary for building the RPM
+    - persist_to_workspace:
+        root: .
+        paths:
+          - target/$TARGET/release/pihole_api
+          - Makefile
+          - LICENSE
+          - debian/pihole-API.service
+          - rpm/pihole-api.spec
     - save_cache:
         key: v3-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
         paths:
           - target
           - /root/.cargo
+
+.rpm_template: &rpm_template
+  docker:
+    - image: pihole/rpm-builder
+  steps:
+    - attach_workspace:
+        at: .
+    - run:
+        name: "Build RPM"
+        command: |
+          mkdir -p ~/rpmbuild/{SOURCES,SPECS}
+          mv rpm/pihole-api.spec ~/rpmbuild/SPECS
+          mv * ~/rpmbuild/SOURCES
+          rpmbuild -bb ~/rpmbuild/SPECS/pihole-api.spec --target $RPM_ARCH
+    - run:
+        name: "Upload"
+        command: |
+          [ -z "$FTL_SECRET" ] && exit 0
+          RPM_PATH=~/rpmbuild/RPMS/$RPM_ARCH/pihole-api*.rpm
+          curl https://ftl.pi-hole.net:8080/FTL-client -o FTL-client
+          chmod +x ./FTL-client
+          [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" "${RPM_PATH}" "${FTL_SECRET}"
+          rm ./FTL-client
 
 jobs:
   arm:
@@ -97,12 +129,24 @@ jobs:
       TARGET: "armv7-unknown-linux-gnueabihf"
       DEB_ARCH: "armhf"
 
+  armhf-rpm:
+    <<: *rpm_template
+    environment:
+      TARGET: "armv7-unknown-linux-gnueabihf"
+      RPM_ARCH: "armhfp"
+
   aarch64:
     <<: *job_template
     environment:
       BIN_NAME: "pihole-API-aarch64-linux-gnu"
       TARGET: "aarch64-unknown-linux-gnu"
       DEB_ARCH: "arm64"
+
+  aarch64-rpm:
+    <<: *rpm_template
+    environment:
+      TARGET: "aarch64-unknown-linux-gnu"
+      RPM_ARCH: "aarch64"
 
   x86_64:
     <<: *job_template
@@ -111,12 +155,24 @@ jobs:
       TARGET: "x86_64-unknown-linux-gnu"
       DEB_ARCH: "amd64"
 
+  x86_64-rpm:
+    <<: *rpm_template
+    environment:
+      TARGET: "x86_64-unknown-linux-gnu"
+      RPM_ARCH: "x86_64"
+
   x86_64-musl:
     <<: *job_template
     environment:
       BIN_NAME: "pihole-API-musl-linux-x86_64"
       TARGET: "x86_64-unknown-linux-musl"
       DEB_ARCH: "musl-linux-amd64"
+
+  x86_64-musl-rpm:
+    <<: *rpm_template
+    environment:
+      TARGET: "x86_64-unknown-linux-musl"
+      RPM_ARCH: "musl-linux-amd64"
 
   x86_32:
     <<: *job_template
@@ -125,13 +181,34 @@ jobs:
       TARGET: "i686-unknown-linux-gnu"
       DEB_ARCH: "i386"
 
+  x86_32-rpm:
+    <<: *rpm_template
+    environment:
+      TARGET: "i686-unknown-linux-gnu"
+      RPM_ARCH: "i386"
+
 workflows:
   version: 2
   build:
     jobs:
       - arm
       - armhf
+      - armhf-rpm:
+          requires:
+            - armhf
       - aarch64
+      - aarch64-rpm:
+          requires:
+            - aarch64
       - x86_64
+      - x86_64-rpm:
+          requires:
+            - x86_64
       - x86_64-musl
+      - x86_64-musl-rpm:
+          requires:
+            - x86_64-musl
       - x86_32
+      - x86_32-rpm:
+          requires:
+            - x86_32

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
     <<: *rpm_template
     environment:
       TARGET: "x86_64-unknown-linux-musl"
-      RPM_ARCH: "musl-linux-amd64"
+      RPM_ARCH: "musl"
 
   x86_32:
     <<: *job_template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ version: 2
     - persist_to_workspace:
         root: .
         paths:
-          - target/$TARGET/release/pihole_api
+          - target/*/release/pihole_api
           - Makefile
           - LICENSE
           - debian/pihole-API.service

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,10 +108,9 @@ version: 2
         name: "Upload"
         command: |
           [ -z "$FTL_SECRET" ] && exit 0
-          RPM_PATH=~/rpmbuild/RPMS/$RPM_ARCH/pihole-api*.rpm
           curl https://ftl.pi-hole.net:8080/FTL-client -o FTL-client
           chmod +x ./FTL-client
-          [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" "${RPM_PATH}" "${FTL_SECRET}"
+          [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" /root/rpmbuild/RPMS/aarch64/pihole-api*.rpm "${FTL_SECRET}"
           rm ./FTL-client
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ version: 2
           [ -z "$FTL_SECRET" ] && exit 0
           curl https://ftl.pi-hole.net:8080/FTL-client -o FTL-client
           chmod +x ./FTL-client
-          [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" /root/rpmbuild/RPMS/aarch64/pihole-api*.rpm "${FTL_SECRET}"
+          [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" /root/rpmbuild/RPMS/$RPM_ARCH/pihole-api*.rpm "${FTL_SECRET}"
           rm ./FTL-client
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,8 @@ version: 2
           [ -z "$FTL_SECRET" ] && exit 0
           curl https://ftl.pi-hole.net:8080/FTL-client -o FTL-client
           chmod +x ./FTL-client
-          [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" /root/rpmbuild/RPMS/$RPM_ARCH/pihole-api*.rpm "${FTL_SECRET}"
+          mv ~/rpmbuild/RPMS/$RPM_ARCH/pihole-api*.rpm .
+          [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" pihole-api*.rpm "${FTL_SECRET}"
           rm ./FTL-client
 
 jobs:

--- a/docker/rpm-builder/Dockerfile
+++ b/docker/rpm-builder/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+
+RUN yum install -y rpm-build rpm-devel make && yum clean all

--- a/rpm/pihole-api.spec
+++ b/rpm/pihole-api.spec
@@ -7,7 +7,6 @@ License:        EUPL-1.2
 URL:            https://pi-hole.net
 
 BuildRequires:  systemd
-Requires:       sqlite-libs
 Requires:       libcap
 %{?systemd_requires}
 

--- a/rpm/pihole-api.spec
+++ b/rpm/pihole-api.spec
@@ -38,7 +38,7 @@ install -m 644 debian/pihole-API.service %{buildroot}%{_unitdir}
 # Only add the user when installing
 if [ $1 -eq 1 ]; then
     # Create a pihole user and group if they don't already exist
-    adduser --system --group --quiet pihole
+    adduser --system --user-group pihole &>/dev/null
 fi
 
 # Give the API permission to bind to low ports

--- a/rpm/pihole-api.spec
+++ b/rpm/pihole-api.spec
@@ -1,0 +1,51 @@
+Name:           pihole-api
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        The Pi-hole API, including the Web Interface
+
+License:        EUPL-1.2
+URL:            https://pi-hole.net
+
+BuildRequires:  systemd
+Requires:       sqlite-libs
+Requires:       libcap
+%{?systemd_requires}
+
+
+%description
+The Pi-hole API provides a RESTful service for the web interface. The web
+interface is embedded into the API and exposed under /admin.
+
+
+%prep
+cp -r %{_sourcedir}/* %{_builddir}
+
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%make_install
+mkdir -p %{buildroot}%{_unitdir}
+install -m 644 debian/pihole-API.service %{buildroot}%{_unitdir}
+
+
+%files
+%license LICENSE
+%{_bindir}/pihole-API
+%{_unitdir}/pihole-API.service
+
+
+%post
+%systemd_post pihole-API.service
+
+
+%preun
+%systemd_preun pihole-API.service
+
+
+%postun
+%systemd_postun_with_restart pihole-API.service
+
+
+%changelog
+* Fri Mar 22 2019 Mark Drobnak <mark.drobnak@pi-hole.net> - 0.1.0-1
+- Initial package

--- a/rpm/pihole-api.spec
+++ b/rpm/pihole-api.spec
@@ -1,6 +1,6 @@
 Name:           pihole-api
 Version:        0.1.0
-Release:        1%{?dist}
+Release:        1
 Summary:        The Pi-hole API, including the Web Interface
 
 License:        EUPL-1.2

--- a/rpm/pihole-api.spec
+++ b/rpm/pihole-api.spec
@@ -35,6 +35,15 @@ install -m 644 debian/pihole-API.service %{buildroot}%{_unitdir}
 
 
 %post
+# Only add the user when installing
+if [ $1 -eq 1 ]; then
+    # Create a pihole user and group if they don't already exist
+    adduser --system --group --quiet pihole
+fi
+
+# Give the API permission to bind to low ports
+setcap CAP_NET_BIND_SERVICE+eip /usr/bin/pihole-API
+
 %systemd_post pihole-API.service
 
 


### PR DESCRIPTION
RPMs are now built. ARM builds are not supplied because CentOS and Fedora only support armv7 and higher (armhf and aarch64 builds are still made).

These RPMs have been tested to work on Fedora. CentOS is unable to handle the glibc version requirement of `x86_64`, and has a linking issue with `x86_64-musl`. These issues are most likely caused by using newer versions of software in the builders (Debian Stretch is newer than CentOS 7). The fix would be to use an older distro like CentOS in the CI, but this change should happen in a different PR.