### PR TITLE
Update shared memory to version 6

### DIFF
--- a/src/ftl/memory_model/client.rs
+++ b/src/ftl/memory_model/client.rs
@@ -39,14 +39,14 @@ pub struct ClientReply {
 #[derive(Copy, Clone)]
 pub struct FtlClient {
     magic: libc::c_uchar,
+    ip_str_id: libc::size_t,
+    name_str_id: libc::size_t,
+    last_query_time: libc::time_t,
     pub query_count: libc::c_int,
     pub blocked_count: libc::c_int,
-    ip_str_id: libc::c_ulonglong,
-    name_str_id: libc::c_ulonglong,
-    is_name_unknown: bool,
     pub over_time: [libc::c_int; OVERTIME_SLOTS],
-    last_query_time: libc::time_t,
-    arp_query_count: libc::c_uint
+    arp_query_count: libc::c_uint,
+    is_name_unknown: bool
 }
 
 impl FtlClient {
@@ -61,8 +61,8 @@ impl FtlClient {
             magic: MAGIC_BYTE,
             query_count: query_count as libc::c_int,
             blocked_count: blocked_count as libc::c_int,
-            ip_str_id: ip_str_id as libc::c_ulonglong,
-            name_str_id: name_str_id.unwrap_or_default() as libc::c_ulonglong,
+            ip_str_id: ip_str_id as libc::size_t,
+            name_str_id: name_str_id.unwrap_or_default() as libc::size_t,
             is_name_unknown: name_str_id.is_none(),
             over_time: [0; OVERTIME_SLOTS],
             last_query_time: 0,

--- a/src/ftl/memory_model/domain.rs
+++ b/src/ftl/memory_model/domain.rs
@@ -20,10 +20,10 @@ use crate::ftl::memory_model::MAGIC_BYTE;
 #[derive(Copy, Clone)]
 pub struct FtlDomain {
     magic: libc::c_uchar,
+    pub regex_match: FtlRegexMatch,
+    domain_str_id: libc::size_t,
     pub query_count: libc::c_int,
-    pub blocked_count: libc::c_int,
-    domain_str_id: libc::c_ulonglong,
-    pub regex_match: FtlRegexMatch
+    pub blocked_count: libc::c_int
 }
 
 impl FtlDomain {
@@ -38,7 +38,7 @@ impl FtlDomain {
             magic: MAGIC_BYTE,
             query_count: total_count as libc::c_int,
             blocked_count: blocked_count as libc::c_int,
-            domain_str_id: domain_str_id as libc::c_ulonglong,
+            domain_str_id: domain_str_id as libc::size_t,
             regex_match
         }
     }

--- a/src/ftl/memory_model/query.rs
+++ b/src/ftl/memory_model/query.rs
@@ -8,16 +8,18 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use crate::ftl::FtlQueryType;
+use crate::{ftl::FtlQueryType, settings::FtlPrivacyLevel};
 use libc;
 use rocket::{http::RawStr, request::FromFormValue};
 
 /// A list of query statuses which mark a query as blocked
-pub const BLOCKED_STATUSES: [i32; 4] = [
+pub const BLOCKED_STATUSES: [i32; 6] = [
     FtlQueryStatus::Gravity as i32,
     FtlQueryStatus::Wildcard as i32,
     FtlQueryStatus::Blacklist as i32,
-    FtlQueryStatus::ExternalBlock as i32
+    FtlQueryStatus::ExternalBlockIp as i32,
+    FtlQueryStatus::ExternalBlockNull as i32,
+    FtlQueryStatus::ExternalBlockNxdomainRa as i32
 ];
 
 /// The query struct stored in shared memory
@@ -36,13 +38,12 @@ pub struct FtlQuery {
     pub database_id: i64,
     pub id: libc::c_int,
     pub is_complete: bool,
-    pub is_private: bool,
+    pub privacy_level: FtlPrivacyLevel,
     /// Saved in units of 1/10 milliseconds (1 = 0.1ms, 2 = 0.2ms,
     /// 2500 = 250.0ms, etc.)
     pub response_time: libc::c_ulong,
     pub reply_type: FtlQueryReplyType,
-    pub dnssec_type: FtlDnssecType,
-    pub ad_bit: bool
+    pub dnssec_type: FtlDnssecType
 }
 
 impl FtlQuery {
@@ -63,7 +64,9 @@ pub enum FtlQueryStatus {
     Cache,
     Wildcard,
     Blacklist,
-    ExternalBlock
+    ExternalBlockIp,
+    ExternalBlockNull,
+    ExternalBlockNxdomainRa
 }
 
 impl FtlQueryStatus {
@@ -76,7 +79,9 @@ impl FtlQueryStatus {
             3 => Some(FtlQueryStatus::Cache),
             4 => Some(FtlQueryStatus::Wildcard),
             5 => Some(FtlQueryStatus::Blacklist),
-            6 => Some(FtlQueryStatus::ExternalBlock),
+            6 => Some(FtlQueryStatus::ExternalBlockIp),
+            7 => Some(FtlQueryStatus::ExternalBlockNull),
+            8 => Some(FtlQueryStatus::ExternalBlockNxdomainRa),
             _ => None
         }
     }

--- a/src/ftl/memory_model/query.rs
+++ b/src/ftl/memory_model/query.rs
@@ -28,22 +28,22 @@ pub const BLOCKED_STATUSES: [i32; 6] = [
 #[derive(Copy, Clone)]
 pub struct FtlQuery {
     pub magic: libc::c_uchar,
-    pub timestamp: libc::time_t,
-    pub time_index: libc::c_uint,
     pub query_type: FtlQueryType,
     pub status: FtlQueryStatus,
+    pub privacy_level: FtlPrivacyLevel,
+    pub reply_type: FtlQueryReplyType,
+    pub dnssec_type: FtlDnssecType,
+    pub timestamp: libc::time_t,
     pub domain_id: libc::c_int,
     pub client_id: libc::c_int,
     pub upstream_id: libc::c_int,
-    pub database_id: i64,
     pub id: libc::c_int,
-    pub is_complete: bool,
-    pub privacy_level: FtlPrivacyLevel,
     /// Saved in units of 1/10 milliseconds (1 = 0.1ms, 2 = 0.2ms,
     /// 2500 = 250.0ms, etc.)
     pub response_time: libc::c_ulong,
-    pub reply_type: FtlQueryReplyType,
-    pub dnssec_type: FtlDnssecType
+    pub database_id: libc::int64_t,
+    pub time_index: libc::c_uint,
+    pub is_complete: bool
 }
 
 impl FtlQuery {

--- a/src/ftl/memory_model/upstream.rs
+++ b/src/ftl/memory_model/upstream.rs
@@ -19,10 +19,10 @@ use crate::ftl::memory_model::MAGIC_BYTE;
 #[derive(Copy, Clone)]
 pub struct FtlUpstream {
     magic: libc::c_uchar,
+    ip_str_id: libc::size_t,
+    name_str_id: libc::size_t,
     pub query_count: libc::c_int,
     pub failed_count: libc::c_int,
-    ip_str_id: libc::c_ulonglong,
-    name_str_id: libc::c_ulonglong,
     is_name_unknown: bool
 }
 
@@ -38,8 +38,8 @@ impl FtlUpstream {
             magic: MAGIC_BYTE,
             query_count: query_count as libc::c_int,
             failed_count: failed_count as libc::c_int,
-            ip_str_id: ip_str_id as libc::c_ulonglong,
-            name_str_id: name_str_id.unwrap_or_default() as libc::c_ulonglong,
+            ip_str_id: ip_str_id as libc::size_t,
+            name_str_id: name_str_id.unwrap_or_default() as libc::size_t,
             is_name_unknown: name_str_id.is_none()
         }
     }

--- a/src/ftl/shared_memory.rs
+++ b/src/ftl/shared_memory.rs
@@ -22,7 +22,7 @@ use crate::{ftl::memory_model::FtlSettings, util::ErrorKind};
 #[cfg(test)]
 use std::collections::HashMap;
 
-const FTL_SHM_VERSION: usize = 4;
+const FTL_SHM_VERSION: usize = 5;
 
 const FTL_SHM_CLIENTS: &str = "/FTL-clients";
 const FTL_SHM_DOMAINS: &str = "/FTL-domains";

--- a/src/ftl/shared_memory.rs
+++ b/src/ftl/shared_memory.rs
@@ -22,7 +22,7 @@ use crate::{ftl::memory_model::FtlSettings, util::ErrorKind};
 #[cfg(test)]
 use std::collections::HashMap;
 
-const FTL_SHM_VERSION: usize = 5;
+const FTL_SHM_VERSION: usize = 6;
 
 const FTL_SHM_CLIENTS: &str = "/FTL-clients";
 const FTL_SHM_DOMAINS: &str = "/FTL-domains";

--- a/src/routes/stats/history/filters/private.rs
+++ b/src/routes/stats/history/filters/private.rs
@@ -8,13 +8,13 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use crate::ftl::FtlQuery;
+use crate::{ftl::FtlQuery, settings::FtlPrivacyLevel};
 
 /// Filter out private queries
 pub fn filter_private_queries<'a>(
     queries_iter: Box<dyn Iterator<Item = &'a FtlQuery> + 'a>
 ) -> Box<dyn Iterator<Item = &'a FtlQuery> + 'a> {
-    Box::new(queries_iter.filter(|query| !query.is_private))
+    Box::new(queries_iter.filter(|query| query.privacy_level < FtlPrivacyLevel::Maximum))
 }
 
 #[cfg(test)]

--- a/src/routes/stats/history/testing.rs
+++ b/src/routes/stats/history/testing.rs
@@ -8,9 +8,12 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use crate::ftl::{
-    FtlClient, FtlCounters, FtlDnssecType, FtlDomain, FtlMemory, FtlQuery, FtlQueryReplyType,
-    FtlQueryStatus, FtlQueryType, FtlRegexMatch, FtlSettings, FtlUpstream, MAGIC_BYTE
+use crate::{
+    ftl::{
+        FtlClient, FtlCounters, FtlDnssecType, FtlDomain, FtlMemory, FtlQuery, FtlQueryReplyType,
+        FtlQueryStatus, FtlQueryType, FtlRegexMatch, FtlSettings, FtlUpstream, MAGIC_BYTE
+    },
+    settings::FtlPrivacyLevel
 };
 use std::collections::HashMap;
 
@@ -25,7 +28,7 @@ macro_rules! query {
             $client:expr,
             $upstream:expr,
             $timestamp:expr,
-            $private:expr
+            $private:ident
         ) => {
         FtlQuery {
             magic: MAGIC_BYTE,
@@ -42,8 +45,7 @@ macro_rules! query {
             reply_type: FtlQueryReplyType::IP,
             dnssec_type: FtlDnssecType::Unspecified,
             is_complete: true,
-            is_private: $private,
-            ad_bit: false
+            privacy_level: FtlPrivacyLevel::$private
         }
     };
 }
@@ -96,17 +98,16 @@ pub fn test_queries() -> Vec<FtlQuery> {
             reply_type: FtlQueryReplyType::CNAME,
             dnssec_type: FtlDnssecType::Secure,
             is_complete: true,
-            is_private: false,
-            ad_bit: false
+            privacy_level: FtlPrivacyLevel::ShowAll
         },
-        query!(2, 96, AAAA, Forward, 0, 0, 0, 263_582, false),
-        query!(3, 97, PTR, Forward, 0, 0, 0, 263_583, false),
-        query!(4, 98, A, Gravity, 1, 1, 0, 263_583, false),
-        query!(5, 99, AAAA, Cache, 0, 1, 0, 263_584, false),
-        query!(6, 100, AAAA, Wildcard, 2, 1, 0, 263_585, false),
-        query!(7, 101, A, Blacklist, 3, 2, 0, 263_585, false),
-        query!(8, 0, AAAA, ExternalBlock, 4, 2, 1, 263_586, false),
-        query!(9, 0, A, Forward, 5, 3, 0, 263_587, true),
+        query!(2, 96, AAAA, Forward, 0, 0, 0, 263_582, ShowAll),
+        query!(3, 97, PTR, Forward, 0, 0, 0, 263_583, ShowAll),
+        query!(4, 98, A, Gravity, 1, 1, 0, 263_583, ShowAll),
+        query!(5, 99, AAAA, Cache, 0, 1, 0, 263_584, ShowAll),
+        query!(6, 100, AAAA, Wildcard, 2, 1, 0, 263_585, ShowAll),
+        query!(7, 101, A, Blacklist, 3, 2, 0, 263_585, ShowAll),
+        query!(8, 0, AAAA, ExternalBlockIp, 4, 2, 1, 263_586, ShowAll),
+        query!(9, 0, A, Forward, 5, 3, 0, 263_587, Maximum),
     ]
 }
 

--- a/src/routes/stats/recent_blocked.rs
+++ b/src/routes/stats/recent_blocked.rs
@@ -72,6 +72,7 @@ mod test {
             FtlCounters, FtlDnssecType, FtlDomain, FtlMemory, FtlQuery, FtlQueryReplyType,
             FtlQueryStatus, FtlQueryType, FtlRegexMatch, FtlSettings, MAGIC_BYTE
         },
+        settings::FtlPrivacyLevel,
         testing::TestBuilder
     };
     use std::collections::HashMap;
@@ -94,8 +95,7 @@ mod test {
                 reply_type: FtlQueryReplyType::IP,
                 dnssec_type: FtlDnssecType::Unspecified,
                 is_complete: true,
-                is_private: false,
-                ad_bit: false
+                privacy_level: FtlPrivacyLevel::ShowAll
             }
         };
     }
@@ -107,7 +107,7 @@ mod test {
             query!(2, Gravity, 1),
             query!(3, Blacklist, 2),
             query!(4, Wildcard, 3),
-            query!(5, ExternalBlock, 4),
+            query!(5, ExternalBlockIp, 4),
             query!(6, Cache, 0),
         ]
     }

--- a/src/settings/privacy_level.rs
+++ b/src/settings/privacy_level.rs
@@ -12,7 +12,9 @@ use crate::util::{Error, ErrorKind};
 use std::str::FromStr;
 
 /// The privacy levels used by FTL
-#[derive(PartialOrd, PartialEq)]
+#[repr(u8)]
+#[cfg_attr(test, derive(Debug))]
+#[derive(PartialOrd, PartialEq, Copy, Clone)]
 pub enum FtlPrivacyLevel {
     ShowAll,
     HideDomains,


### PR DESCRIPTION
This PR updates shared memory from version 4 to 6, with a hop to 5 in between (in case it's needed for something). Now the API is again compatible with the development version of FTL.