### PR TITLE
Fix list not found error, and refactor some Env::Test interactions

### DIFF
--- a/src/routes/dns/get_list.rs
+++ b/src/routes/dns/get_list.rs
@@ -32,35 +32,3 @@ pub fn get_blacklist(env: State<Env>) -> Reply {
 pub fn get_regexlist(env: State<Env>) -> Reply {
     reply_result(List::Regex.get(&env))
 }
-
-#[cfg(test)]
-mod test {
-    use crate::{env::PiholeFile, testing::TestBuilder};
-
-    #[test]
-    fn test_get_whitelist() {
-        TestBuilder::new()
-            .endpoint("/admin/api/dns/whitelist")
-            .file(PiholeFile::Whitelist, "example.com\nexample.net\n")
-            .expect_json(json!(["example.com", "example.net"]))
-            .test();
-    }
-
-    #[test]
-    fn test_get_blacklist() {
-        TestBuilder::new()
-            .endpoint("/admin/api/dns/blacklist")
-            .file(PiholeFile::Blacklist, "example.com\nexample.net\n")
-            .expect_json(json!(["example.com", "example.net"]))
-            .test();
-    }
-
-    #[test]
-    fn test_get_regexlist() {
-        TestBuilder::new()
-            .endpoint("/admin/api/dns/regexlist")
-            .file(PiholeFile::Regexlist, "^.*example.com$\nexample.net\n")
-            .expect_json(json!(["^.*example.com$", "example.net"]))
-            .test();
-    }
-}

--- a/src/routes/dns/list.rs
+++ b/src/routes/dns/list.rs
@@ -42,17 +42,12 @@ impl List {
 
     /// Read in the domains from the list
     pub fn get(&self, env: &Env) -> Result<Vec<String>, Error> {
-        let domains = match env.read_file_lines(self.file()) {
-            Ok(domains) => domains,
-            Err(e) => {
-                if e.kind() == ErrorKind::NotFound {
-                    // If the file is not found, then the list is empty
-                    return Ok(Vec::new());
-                } else {
-                    return Err(e);
-                }
-            }
-        };
+        if !env.file_exists(self.file()) {
+            // If the file is not found, then the list is empty
+            return Ok(Vec::new());
+        }
+
+        let domains = env.read_file_lines(self.file())?;
 
         Ok(domains
             .into_iter()
@@ -126,5 +121,75 @@ impl List {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::List;
+    use crate::testing::TestEnvBuilder;
+
+    /// Populate the list file with the initial data (if it exists), read the
+    /// list, and assert that we got back the expected data.
+    fn get_test(list: List, expected: Vec<String>, initial_data: Option<&str>) {
+        let env = if let Some(initial_data) = initial_data {
+            TestEnvBuilder::new()
+                .file(list.file(), initial_data)
+                .build()
+        } else {
+            TestEnvBuilder::new().build()
+        };
+
+        let actual = list.get(&env).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    /// The whitelist is retrieved when it exists
+    #[test]
+    fn get_whitelist() {
+        get_test(
+            List::White,
+            vec!["example.com".to_owned(), "example.net".to_owned()],
+            Some("example.com\nexample.net\n")
+        );
+    }
+
+    /// The whitelist is empty when the file does not exist
+    #[test]
+    fn get_whitelist_empty() {
+        get_test(List::White, Vec::new(), None);
+    }
+
+    /// The blacklist is retrieved when it exists
+    #[test]
+    fn get_blacklist() {
+        get_test(
+            List::Black,
+            vec!["example.com".to_owned(), "example.net".to_owned()],
+            Some("example.com\nexample.net\n")
+        );
+    }
+
+    /// The blacklist is empty when the file does not exist
+    #[test]
+    fn get_blacklist_empty() {
+        get_test(List::Black, Vec::new(), None);
+    }
+
+    /// The regexlist is retrieved when it exists
+    #[test]
+    fn get_regexlist() {
+        get_test(
+            List::Regex,
+            vec!["^.*example.com$".to_owned(), "example.net".to_owned()],
+            Some("^.*example.com$\nexample.net\n")
+        );
+    }
+
+    /// The regexlist is empty when the file does not exist
+    #[test]
+    fn get_regexlist_empty() {
+        get_test(List::Regex, Vec::new(), None);
     }
 }

--- a/src/routes/dns/status.rs
+++ b/src/routes/dns/status.rs
@@ -150,7 +150,7 @@ pub struct ChangeStatus {
 mod test {
     use super::{disable, enable};
     use crate::{
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         testing::{TestBuilder, TestEnvBuilder},
         util::ErrorKind
     };
@@ -209,12 +209,9 @@ mod test {
     /// Return an error if blocking is enabled and we try to enable it again
     #[test]
     fn action_enable_error() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "BLOCKING_ENABLED=true")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "BLOCKING_ENABLED=true")
+            .build();
 
         assert_eq!(
             enable(&env).map_err(|e| e.kind()),
@@ -245,12 +242,9 @@ mod test {
     /// Return an error if blocking is disabled and we try to disable it again
     #[test]
     fn action_disable_error() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "BLOCKING_ENABLED=false")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "BLOCKING_ENABLED=false")
+            .build();
 
         assert_eq!(
             disable(&env, None, None).map_err(|e| e.kind()),

--- a/src/routes/stats/clients.rs
+++ b/src/routes/stats/clients.rs
@@ -141,6 +141,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/clients")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!([
                 { "name": "client1", "ip": "10.1.1.1" },
                 { "name": "",        "ip": "10.1.1.2" },
@@ -166,6 +168,8 @@ mod test {
     fn inactive_clients() {
         TestBuilder::new()
             .endpoint("/admin/api/stats/clients?inactive=true")
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .ftl_memory(test_data())
             .expect_json(json!([
                 { "name": "client1", "ip": "10.1.1.1" },
@@ -187,6 +191,7 @@ mod test {
                 PiholeFile::SetupVars,
                 "API_EXCLUDE_CLIENTS=client3,10.1.1.2"
             )
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!([
                 { "name": "client1", "ip": "10.1.1.1" },
                 { "name": "",        "ip": "10.1.1.4" }

--- a/src/routes/stats/common.rs
+++ b/src/routes/stats/common.rs
@@ -144,7 +144,7 @@ mod tests {
         remove_hidden_domains
     };
     use crate::{
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         ftl::{
             FtlClient, FtlCounters, FtlDomain, FtlMemory, FtlRegexMatch, FtlSettings, ShmLockGuard
         },
@@ -188,15 +188,12 @@ mod tests {
     fn excluded_clients() {
         let ftl_memory = test_data();
 
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(
-                    PiholeFile::SetupVars,
-                    "API_EXCLUDE_CLIENTS=10.1.1.2,client1"
-                )
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(
+                PiholeFile::SetupVars,
+                "API_EXCLUDE_CLIENTS=10.1.1.2,client1"
+            )
+            .build();
 
         let lock_guard = ShmLockGuard::Test;
         let clients = ftl_memory.clients(&lock_guard).unwrap();
@@ -217,15 +214,12 @@ mod tests {
     fn excluded_domains() {
         let ftl_memory = test_data();
 
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(
-                    PiholeFile::SetupVars,
-                    "API_EXCLUDE_DOMAINS=google.com,example.com"
-                )
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(
+                PiholeFile::SetupVars,
+                "API_EXCLUDE_DOMAINS=google.com,example.com"
+            )
+            .build();
 
         let lock_guard = ShmLockGuard::Test;
         let domains = ftl_memory.domains(&lock_guard).unwrap();

--- a/src/routes/stats/database/over_time_clients_db.rs
+++ b/src/routes/stats/database/over_time_clients_db.rs
@@ -179,7 +179,7 @@ mod test {
     use super::{get_client_identifiers, get_client_over_time, over_time_clients_db_impl};
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         ftl::ClientReply,
         routes::stats::over_time_clients::{OverTimeClientItem, OverTimeClients},
         testing::TestEnvBuilder
@@ -221,7 +221,9 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .build();
         let actual =
             over_time_clients_db_impl(FROM_TIMESTAMP, UNTIL_TIMESTAMP, INTERVAL, &db, &env)
                 .unwrap();
@@ -236,7 +238,9 @@ mod test {
         let expected = vec!["127.0.0.1".to_owned(), "10.1.1.1".to_owned()];
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .build();
         let actual = get_client_identifiers(FROM_TIMESTAMP, UNTIL_TIMESTAMP, &db, &env).unwrap();
 
         assert_eq!(actual, expected);

--- a/src/routes/stats/database/over_time_clients_db.rs
+++ b/src/routes/stats/database/over_time_clients_db.rs
@@ -248,12 +248,9 @@ mod test {
         let expected = vec!["127.0.0.1".to_owned()];
 
         let db = connect_to_test_db();
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=10.1.1.1")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=10.1.1.1")
+            .build();
         let actual = get_client_identifiers(FROM_TIMESTAMP, UNTIL_TIMESTAMP, &db, &env).unwrap();
 
         assert_eq!(actual, expected);

--- a/src/routes/stats/database/summary_db.rs
+++ b/src/routes/stats/database/summary_db.rs
@@ -173,11 +173,11 @@ mod test {
     };
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env},
+        env::PiholeFile,
         ftl::FtlQueryStatus,
-        routes::stats::summary::{ReplyTypes, Summary, TotalQueries}
+        routes::stats::summary::{ReplyTypes, Summary, TotalQueries},
+        testing::TestEnvBuilder
     };
-    use std::collections::HashMap;
 
     const FROM_TIMESTAMP: u64 = 0;
     const UNTIL_TIMESTAMP: u64 = 177_180;
@@ -214,7 +214,9 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .build();
         let actual_summary = get_summary_impl(FROM_TIMESTAMP, UNTIL_TIMESTAMP, &db, &env).unwrap();
 
         assert_eq!(actual_summary, expected_summary);

--- a/src/routes/stats/database/top_clients_db.rs
+++ b/src/routes/stats/database/top_clients_db.rs
@@ -183,11 +183,10 @@ mod test {
     use super::top_clients_db_impl;
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         routes::stats::top_clients::{TopClientItemReply, TopClientParams, TopClientsReply},
         testing::TestEnvBuilder
     };
-    use std::collections::HashMap;
 
     const FROM_TIMESTAMP: u64 = 0;
     const UNTIL_TIMESTAMP: u64 = 177_180;
@@ -213,7 +212,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopClientParams::default();
         let actual =
             top_clients_db_impl(&env, &db, FROM_TIMESTAMP, UNTIL_TIMESTAMP, params).unwrap();
@@ -232,7 +234,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopClientParams {
             blocked: Some(true),
             ..TopClientParams::default()
@@ -257,7 +262,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopClientParams {
             limit: Some(1),
             ..TopClientParams::default()
@@ -289,7 +297,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopClientParams {
             ascending: Some(true),
             ..TopClientParams::default()
@@ -360,6 +371,7 @@ mod test {
         let db = connect_to_test_db();
         let env = TestEnvBuilder::new()
             .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=127.0.0.1")
+            .file(PiholeFile::FtlConfig, "")
             .build();
         let params = TopClientParams::default();
         let actual =

--- a/src/routes/stats/database/top_clients_db.rs
+++ b/src/routes/stats/database/top_clients_db.rs
@@ -310,12 +310,9 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::FtlConfig, "PRIVACYLEVEL=2")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::FtlConfig, "PRIVACYLEVEL=2")
+            .build();
         let params = TopClientParams::default();
         let actual =
             top_clients_db_impl(&env, &db, FROM_TIMESTAMP, UNTIL_TIMESTAMP, params).unwrap();
@@ -334,12 +331,9 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::FtlConfig, "PRIVACYLEVEL=2")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::FtlConfig, "PRIVACYLEVEL=2")
+            .build();
         let params = TopClientParams {
             blocked: Some(true),
             ..TopClientParams::default()
@@ -364,12 +358,9 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=127.0.0.1")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=127.0.0.1")
+            .build();
         let params = TopClientParams::default();
         let actual =
             top_clients_db_impl(&env, &db, FROM_TIMESTAMP, UNTIL_TIMESTAMP, params).unwrap();

--- a/src/routes/stats/database/top_domains_db.rs
+++ b/src/routes/stats/database/top_domains_db.rs
@@ -183,11 +183,10 @@ mod test {
     use super::top_domains_db_impl;
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         routes::stats::top_domains::{TopDomainItemReply, TopDomainParams, TopDomainsReply},
         testing::TestEnvBuilder
     };
-    use std::collections::HashMap;
 
     const FROM_TIMESTAMP: u64 = 0;
     const UNTIL_TIMESTAMP: u64 = 177_180;
@@ -244,7 +243,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopDomainParams::default();
         let actual =
             top_domains_db_impl(&env, &db, FROM_TIMESTAMP, UNTIL_TIMESTAMP, params).unwrap();
@@ -271,7 +273,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopDomainParams {
             limit: Some(2),
             ..TopDomainParams::default()
@@ -294,7 +299,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopDomainParams {
             blocked: Some(true),
             ..TopDomainParams::default()
@@ -325,7 +333,10 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
+            .build();
         let params = TopDomainParams {
             ascending: Some(true),
             limit: Some(2),
@@ -358,6 +369,8 @@ mod test {
 
         let db = connect_to_test_db();
         let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .file(PiholeFile::AuditLog, "1.ubuntu.pool.ntp.org")
             .build();
         let params = TopDomainParams {
@@ -395,6 +408,8 @@ mod test {
                 PiholeFile::SetupVars,
                 "API_EXCLUDE_DOMAINS=1.ubuntu.pool.ntp.org"
             )
+            .file(PiholeFile::FtlConfig, "")
+            .file(PiholeFile::AuditLog, "")
             .build();
         let params = TopDomainParams {
             audit: Some(true),

--- a/src/routes/stats/database/top_domains_db.rs
+++ b/src/routes/stats/database/top_domains_db.rs
@@ -357,12 +357,9 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::AuditLog, "1.ubuntu.pool.ntp.org")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::AuditLog, "1.ubuntu.pool.ntp.org")
+            .build();
         let params = TopDomainParams {
             audit: Some(true),
             limit: Some(2),
@@ -393,15 +390,12 @@ mod test {
         };
 
         let db = connect_to_test_db();
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(
-                    PiholeFile::SetupVars,
-                    "API_EXCLUDE_DOMAINS=1.ubuntu.pool.ntp.org"
-                )
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(
+                PiholeFile::SetupVars,
+                "API_EXCLUDE_DOMAINS=1.ubuntu.pool.ntp.org"
+            )
+            .build();
         let params = TopDomainParams {
             audit: Some(true),
             limit: Some(2),

--- a/src/routes/stats/history/database.rs
+++ b/src/routes/stats/history/database.rs
@@ -103,15 +103,17 @@ mod test {
     use super::load_queries_from_database;
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env},
-        routes::stats::history::endpoints::{HistoryCursor, HistoryParams}
+        env::PiholeFile,
+        routes::stats::history::endpoints::{HistoryCursor, HistoryParams},
+        testing::TestEnvBuilder
     };
-    use std::collections::HashMap;
 
     /// Queries are ordered by id, descending
     #[test]
     fn order_by_id() {
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .build();
 
         let (queries, cursor) = load_queries_from_database(
             &connect_to_test_db(),
@@ -130,7 +132,9 @@ mod test {
     /// The max number of queries returned is specified by the limit
     #[test]
     fn limit() {
-        let env = Env::Test(Config::default(), HashMap::new());
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "")
+            .build();
         let expected_cursor = Some(HistoryCursor {
             id: None,
             db_id: Some(1)

--- a/src/routes/stats/history/filters/exclude_clients.rs
+++ b/src/routes/stats/history/filters/exclude_clients.rs
@@ -96,7 +96,7 @@ mod tests {
     use super::{filter_excluded_clients, filter_excluded_clients_db};
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         ftl::{FtlQuery, ShmLockGuard},
         routes::stats::history::{
             database::execute_query,
@@ -109,12 +109,9 @@ mod tests {
     /// No queries should be filtered out if `API_EXCLUDE_CLIENTS` is empty
     #[test]
     fn clients_empty() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=")
+            .build();
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> = queries.iter().collect();
         let filtered_queries: Vec<&FtlQuery> = filter_excluded_clients(
@@ -133,12 +130,9 @@ mod tests {
     /// removed
     #[test]
     fn clients() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=192.168.1.11")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=192.168.1.11")
+            .build();
         let queries = test_queries();
         let expected_queries = vec![
             &queries[0],
@@ -166,12 +160,9 @@ mod tests {
     fn clients_db() {
         use crate::databases::ftl::queries::dsl::*;
 
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=127.0.0.1")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=127.0.0.1")
+            .build();
 
         let db_query = filter_excluded_clients_db(queries.into_boxed(), &env).unwrap();
         let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();

--- a/src/routes/stats/history/filters/exclude_domains.rs
+++ b/src/routes/stats/history/filters/exclude_domains.rs
@@ -93,7 +93,7 @@ mod tests {
     use super::{filter_excluded_domains, filter_excluded_domains_db};
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         ftl::{FtlQuery, ShmLockGuard},
         routes::stats::history::{
             database::execute_query,
@@ -106,12 +106,9 @@ mod tests {
     /// No queries should be filtered out if `API_EXCLUDE_DOMAINS` is empty
     #[test]
     fn domains_empty() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=")
+            .build();
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> = queries.iter().collect();
         let filtered_queries: Vec<&FtlQuery> = filter_excluded_domains(
@@ -130,12 +127,9 @@ mod tests {
     /// removed
     #[test]
     fn domains() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=domain2.com")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=domain2.com")
+            .build();
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> =
             queries.iter().filter(|query| query.id != 4).collect();
@@ -157,15 +151,12 @@ mod tests {
     fn domains_db() {
         use crate::databases::ftl::queries::dsl::*;
 
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(
-                    PiholeFile::SetupVars,
-                    "API_EXCLUDE_DOMAINS=0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org"
-                )
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(
+                PiholeFile::SetupVars,
+                "API_EXCLUDE_DOMAINS=0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org"
+            )
+            .build();
 
         let db_query = filter_excluded_domains_db(queries.into_boxed(), &env).unwrap();
         let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();

--- a/src/routes/stats/history/filters/setup_vars.rs
+++ b/src/routes/stats/history/filters/setup_vars.rs
@@ -54,7 +54,7 @@ mod test {
     use super::{filter_setup_vars_setting, filter_setup_vars_setting_db};
     use crate::{
         databases::ftl::connect_to_test_db,
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         ftl::{FtlQuery, BLOCKED_STATUSES},
         routes::stats::history::{database::execute_query, testing::test_queries},
         testing::TestEnvBuilder
@@ -64,12 +64,9 @@ mod test {
     /// No queries should be shown if `API_QUERY_LOG_SHOW` equals `nothing`
     #[test]
     fn setting_is_nothing() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=nothing")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=nothing")
+            .build();
         let queries = test_queries();
         let filtered_queries: Vec<&FtlQuery> =
             filter_setup_vars_setting(Box::new(queries.iter()), &env)
@@ -83,12 +80,9 @@ mod test {
     /// `permittedonly`
     #[test]
     fn setting_is_permitted() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=permittedonly")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=permittedonly")
+            .build();
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> = vec![
             &queries[0],
@@ -109,12 +103,9 @@ mod test {
     /// `blockedonly`
     #[test]
     fn setting_is_blocked() {
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=blockedonly")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=blockedonly")
+            .build();
         let queries = test_queries();
         let expected_queries: Vec<&FtlQuery> =
             vec![&queries[3], &queries[5], &queries[6], &queries[7]];
@@ -132,12 +123,9 @@ mod test {
     fn setting_is_nothing_db() {
         use crate::databases::ftl::queries::dsl::*;
 
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=nothing")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=nothing")
+            .build();
 
         let db_query = filter_setup_vars_setting_db(queries.into_boxed(), &env).unwrap();
         let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
@@ -151,12 +139,9 @@ mod test {
     fn setting_is_permitted_db() {
         use crate::databases::ftl::queries::dsl::*;
 
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=permittedonly")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=permittedonly")
+            .build();
 
         let db_query = filter_setup_vars_setting_db(queries.into_boxed(), &env).unwrap();
         let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();
@@ -172,12 +157,9 @@ mod test {
     fn setting_is_blocked_db() {
         use crate::databases::ftl::queries::dsl::*;
 
-        let env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=blockedonly")
-                .build()
-        );
+        let env = TestEnvBuilder::new()
+            .file(PiholeFile::SetupVars, "API_QUERY_LOG_SHOW=blockedonly")
+            .build();
 
         let db_query = filter_setup_vars_setting_db(queries.into_boxed(), &env).unwrap();
         let filtered_queries = execute_query(&connect_to_test_db(), db_query).unwrap();

--- a/src/routes/stats/history/get_history.rs
+++ b/src/routes/stats/history/get_history.rs
@@ -226,6 +226,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/history")
             .ftl_memory(ftl_memory)
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .need_database(true)
             .expect_json(json!({
                 "history": history,
@@ -253,6 +255,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/history?limit=5")
             .ftl_memory(ftl_memory)
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .need_database(true)
             .expect_json(json!({
                 "history": history,
@@ -282,6 +286,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/history?from=177180&until=177181")
             .ftl_memory(test_memory())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .need_database(true)
             .expect_json(json!({
                 "history": [

--- a/src/routes/stats/over_time_clients.rs
+++ b/src/routes/stats/over_time_clients.rs
@@ -179,6 +179,7 @@ mod test {
             .endpoint("/admin/api/stats/overTime/clients")
             .ftl_memory(test_data())
             .file(PiholeFile::SetupVars, "API_EXCLUDE_CLIENTS=client1")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "clients": [
                     { "name": "",        "ip": "10.1.1.2" },

--- a/src/routes/stats/recent_blocked.rs
+++ b/src/routes/stats/recent_blocked.rs
@@ -68,6 +68,7 @@ pub fn get_recent_blocked(ftl_memory: &FtlMemory, env: &Env, num: usize) -> Repl
 #[cfg(test)]
 mod test {
     use crate::{
+        env::PiholeFile,
         ftl::{
             FtlCounters, FtlDnssecType, FtlDomain, FtlMemory, FtlQuery, FtlQueryReplyType,
             FtlQueryStatus, FtlQueryType, FtlRegexMatch, FtlSettings, MAGIC_BYTE
@@ -159,6 +160,7 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/recent_blocked")
             .ftl_memory(test_memory())
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!(["domain5.com"]))
             .test();
     }
@@ -169,6 +171,7 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/recent_blocked?num=3")
             .ftl_memory(test_memory())
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!(["domain5.com", "domain4.com", "domain3.com"]))
             .test();
     }
@@ -179,6 +182,7 @@ mod test {
     fn less_than_requested() {
         TestBuilder::new()
             .endpoint("/admin/api/stats/recent_blocked?num=10")
+            .file(PiholeFile::FtlConfig, "")
             .ftl_memory(test_memory())
             .expect_json(json!([
                 "domain5.com",

--- a/src/routes/stats/summary.rs
+++ b/src/routes/stats/summary.rs
@@ -195,6 +195,7 @@ mod test {
             .endpoint("/admin/api/stats/summary")
             .ftl_memory(test_data())
             .file(PiholeFile::SetupVars, "BLOCKING_ENABLED=true")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "gravity_size": 100_000,
                 "total_queries": {

--- a/src/routes/stats/top_clients.rs
+++ b/src/routes/stats/top_clients.rs
@@ -234,6 +234,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_clients")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_clients": [
                     { "name": "",        "ip": "10.1.1.4", "count": 40 },
@@ -253,6 +255,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_clients?blocked=true")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_clients": [
                     { "name": "client1", "ip": "10.1.1.1", "count": 10 },
@@ -269,6 +273,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_clients?limit=2")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_clients": [
                     { "name": "",        "ip": "10.1.1.4", "count": 40 },
@@ -285,6 +291,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_clients?ascending=true")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_clients": [
                     { "name": "client3", "ip": "10.1.1.3", "count": 10 },
@@ -332,6 +340,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_clients?inactive=true")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_clients": [
                     { "name": "",        "ip": "10.1.1.4", "count": 40 },
@@ -355,6 +365,7 @@ mod test {
                 PiholeFile::SetupVars,
                 "API_EXCLUDE_CLIENTS=client3,10.1.1.2"
             )
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_clients": [
                     { "name": "",        "ip": "10.1.1.4", "count": 40 },

--- a/src/routes/stats/top_domains.rs
+++ b/src/routes/stats/top_domains.rs
@@ -282,6 +282,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_domains")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_domains": [
                     { "domain": "github.com", "count": 20 },
@@ -298,6 +300,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_domains?limit=1")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_domains": [
                     { "domain": "github.com", "count": 20 }
@@ -314,6 +318,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_domains?blocked=true")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_domains": [
                     { "domain": "example.com", "count": 10 },
@@ -331,6 +337,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_domains?ascending=true")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_domains": [
                     { "domain": "example.net", "count": 1 },
@@ -348,6 +356,8 @@ mod test {
         TestBuilder::new()
             .endpoint("/admin/api/stats/top_domains?audit=true")
             .ftl_memory(test_data())
+            .file(PiholeFile::SetupVars, "")
+            .file(PiholeFile::FtlConfig, "")
             .file(PiholeFile::AuditLog, "example.net")
             .expect_json(json!({
                 "top_domains": [
@@ -365,6 +375,7 @@ mod test {
             .endpoint("/admin/api/stats/top_domains")
             .ftl_memory(test_data())
             .file(PiholeFile::SetupVars, "API_EXCLUDE_DOMAINS=example.net")
+            .file(PiholeFile::FtlConfig, "")
             .expect_json(json!({
                 "top_domains": [
                     { "domain": "github.com", "count": 20 }

--- a/src/routes/version.rs
+++ b/src/routes/version.rs
@@ -143,7 +143,7 @@ struct Version {
 mod tests {
     use super::{parse_git_version, parse_web_version, read_ftl_version, Version};
     use crate::{
-        env::{Config, Env, PiholeFile},
+        env::PiholeFile,
         ftl::FtlConnectionType,
         routes::version::read_core_version,
         testing::{write_eom, TestEnvBuilder},
@@ -248,19 +248,16 @@ mod tests {
 
     #[test]
     fn test_read_core_version_valid() {
-        let test_env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(
-                    PiholeFile::LocalVersions,
-                    "v3.3.1-219-g6689e00 v3.3-190-gf7e1a28 vDev-d06deca"
-                )
-                .file(
-                    PiholeFile::LocalBranches,
-                    "development devel tweak/getClientNames"
-                )
-                .build()
-        );
+        let test_env = TestEnvBuilder::new()
+            .file(
+                PiholeFile::LocalVersions,
+                "v3.3.1-219-g6689e00 v3.3-190-gf7e1a28 vDev-d06deca"
+            )
+            .file(
+                PiholeFile::LocalBranches,
+                "development devel tweak/getClientNames"
+            )
+            .build();
 
         assert_eq!(
             read_core_version(&test_env).map_err(|e| e.kind()),
@@ -274,19 +271,16 @@ mod tests {
 
     #[test]
     fn test_read_core_version_invalid() {
-        let test_env = Env::Test(
-            Config::default(),
-            TestEnvBuilder::new()
-                .file(
-                    PiholeFile::LocalVersions,
-                    "invalid v3.3-190-gf7e1a28 vDev-d06deca"
-                )
-                .file(
-                    PiholeFile::LocalBranches,
-                    "development devel tweak/getClientNames"
-                )
-                .build()
-        );
+        let test_env = TestEnvBuilder::new()
+            .file(
+                PiholeFile::LocalVersions,
+                "invalid v3.3-190-gf7e1a28 vDev-d06deca"
+            )
+            .file(
+                PiholeFile::LocalBranches,
+                "development devel tweak/getClientNames"
+            )
+            .build();
 
         assert_eq!(
             read_core_version(&test_env).map_err(|e| e.kind()),

--- a/src/settings/dnsmasq.rs
+++ b/src/settings/dnsmasq.rs
@@ -222,7 +222,7 @@ mod tests {
         DNSMASQ_HEADER
     };
     use crate::{
-        env::{Config, Env, PiholeFile},
+        env::{Env, PiholeFile},
         testing::TestEnvBuilder,
         util::Error
     };
@@ -250,8 +250,8 @@ mod tests {
             .file_expect(PiholeFile::DnsmasqConfig, "", expected_config)
             .file(PiholeFile::SetupVars, setup_vars);
 
-        let mut dnsmasq_config = env_builder.get_test_files().into_iter().next().unwrap();
-        let env = Env::Test(Config::default(), env_builder.build());
+        let mut dnsmasq_config = env_builder.clone_test_files().into_iter().next().unwrap();
+        let env = env_builder.build();
         let mut file_writer = open_config(&env).unwrap();
 
         test_fn(&mut file_writer, &env).unwrap();

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -424,10 +424,7 @@ impl ConfigEntry for FtlConfEntry {
 #[cfg(test)]
 mod tests {
     use super::{ConfigEntry, SetupVarsEntry};
-    use crate::{
-        env::{Config, Env, PiholeFile},
-        testing::TestEnvBuilder
-    };
+    use crate::{env::PiholeFile, testing::TestEnvBuilder};
 
     /// Test to make sure when writing a setting, a similar setting does not
     /// get deleted. Example: Adding PIHOLE_DNS_1 should not delete
@@ -440,8 +437,8 @@ mod tests {
             "PIHOLE_DNS_10=1.1.1.1\n\
              PIHOLE_DNS_1=2.2.2.2\n"
         );
-        let mut test_file = env_builder.get_test_files().into_iter().next().unwrap();
-        let env = Env::Test(Config::default(), env_builder.build());
+        let mut test_file = env_builder.clone_test_files().into_iter().next().unwrap();
+        let env = env_builder.build();
 
         SetupVarsEntry::PiholeDns(1).write("2.2.2.2", &env).unwrap();
 
@@ -453,8 +450,8 @@ mod tests {
     fn delete_value() {
         let env_builder =
             TestEnvBuilder::new().file_expect(PiholeFile::SetupVars, "PIHOLE_DNS_1=1.2.3.4\n", "");
-        let mut test_file = env_builder.get_test_files().into_iter().next().unwrap();
-        let env = Env::Test(Config::default(), env_builder.build());
+        let mut test_file = env_builder.clone_test_files().into_iter().next().unwrap();
+        let env = env_builder.build();
 
         SetupVarsEntry::PiholeDns(1).write("", &env).unwrap();
 
@@ -470,8 +467,8 @@ mod tests {
              PIHOLE_DNS_1=1.2.3.4\n",
             "PIHOLE_DNS_1=5.6.7.8\n"
         );
-        let mut test_file = env_builder.get_test_files().into_iter().next().unwrap();
-        let env = Env::Test(Config::default(), env_builder.build());
+        let mut test_file = env_builder.clone_test_files().into_iter().next().unwrap();
+        let env = env_builder.build();
 
         SetupVarsEntry::PiholeDns(1).write("5.6.7.8", &env).unwrap();
 
@@ -486,8 +483,8 @@ mod tests {
             "PIHOLE_DNS_1=\n",
             "PIHOLE_DNS_1=1.2.3.4\n"
         );
-        let mut test_file = env_builder.get_test_files().into_iter().next().unwrap();
-        let env = Env::Test(Config::default(), env_builder.build());
+        let mut test_file = env_builder.clone_test_files().into_iter().next().unwrap();
+        let env = env_builder.build();
 
         SetupVarsEntry::PiholeDns(1).write("1.2.3.4", &env).unwrap();
 
@@ -499,8 +496,8 @@ mod tests {
     fn write_to_empty_file() {
         let env_builder =
             TestEnvBuilder::new().file_expect(PiholeFile::SetupVars, "", "PIHOLE_DNS_1=1.1.1.1\n");
-        let mut test_file = env_builder.get_test_files().into_iter().next().unwrap();
-        let env = Env::Test(Config::default(), env_builder.build());
+        let mut test_file = env_builder.clone_test_files().into_iter().next().unwrap();
+        let env = env_builder.build();
 
         SetupVarsEntry::PiholeDns(1).write("1.1.1.1", &env).unwrap();
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -23,13 +23,11 @@ use rocket::config::{ConfigBuilder, Environment};
 use rocket_cors::Cors;
 
 #[cfg(test)]
-use crate::{databases::load_test_databases, env::PiholeFile};
+use crate::databases::load_test_databases;
 #[cfg(test)]
 use rocket::{config::LoggingLevel, local::Client};
 #[cfg(test)]
 use std::collections::HashMap;
-#[cfg(test)]
-use tempfile::NamedTempFile;
 
 const CONFIG_LOCATION: &str = "/etc/pihole/API.toml";
 
@@ -75,11 +73,9 @@ pub fn start() -> Result<(), Error> {
 pub fn test(
     ftl_data: HashMap<String, Vec<u8>>,
     ftl_memory: FtlMemory,
-    env_data: HashMap<PiholeFile, NamedTempFile>,
+    env: Env,
     needs_database: bool
 ) -> Client {
-    use toml;
-
     Client::new(setup(
         rocket::custom(
             ConfigBuilder::new(Environment::Development)
@@ -90,7 +86,7 @@ pub fn test(
         ),
         FtlConnectionType::Test(ftl_data),
         ftl_memory,
-        Env::Test(toml::from_str("").unwrap(), env_data),
+        env,
         "test_key".to_owned(),
         needs_database
     ))


### PR DESCRIPTION
Fixes #122 

Included in this PR are two small refactors, which impacted a lot of files. See the commit messages for more information:
- Changed `TestEnvBuilder` to build a full `Env::Test` object
- If a file is not configured in the test `Env`, then return an error if something tries to access it