### PR TITLE
Use ValueType::Regex and ValueType::Hostname when checking list acceptance

### DIFF
--- a/src/routes/dns/common.rs
+++ b/src/routes/dns/common.rs
@@ -18,27 +18,7 @@ use nix::{
     sys::signal::{kill, Signal},
     unistd::Pid
 };
-use regex::Regex;
 use std::process::{Command, Stdio};
-
-/// Check if a domain is valid
-pub fn is_valid_domain(domain: &str) -> bool {
-    let valid_chars_regex = Regex::new(
-        "^((-|_)*[a-z0-9]((-|_)*[a-z0-9])*(-|_)*)(\\.(-|_)*([a-z0-9]((-|_)*[a-z0-9])*))*$"
-    )
-    .unwrap();
-    let total_length_regex = Regex::new("^.{1,253}$").unwrap();
-    let label_length_regex = Regex::new("^[^\\.]{1,63}(\\.[^\\.]{1,63})*$").unwrap();
-
-    valid_chars_regex.is_match(domain)
-        && total_length_regex.is_match(domain)
-        && label_length_regex.is_match(domain)
-}
-
-/// Check if a regex is valid
-pub fn is_valid_regex(regex_str: &str) -> bool {
-    Regex::new(regex_str).is_ok()
-}
 
 /// Reload Gravity to activate changes in lists
 pub fn reload_gravity(list: List, env: &Env) -> Result<(), Error> {

--- a/src/routes/dns/list.rs
+++ b/src/routes/dns/list.rs
@@ -10,7 +10,7 @@
 
 use crate::{
     env::{Env, PiholeFile},
-    routes::dns::common::{is_valid_domain, is_valid_regex},
+    settings::ValueType,
     util::{Error, ErrorKind}
 };
 use failure::ResultExt;
@@ -35,8 +35,9 @@ impl List {
     /// Check if the list accepts the domain as valid
     fn accepts(&self, domain: &str) -> bool {
         match *self {
-            List::Regex => is_valid_regex(domain),
-            _ => is_valid_domain(domain)
+            List::Regex => ValueType::Regex.is_valid(domain),
+            // Allow hostnames to be white/blacklist-ed
+            _ => ValueType::Hostname.is_valid(domain)
         }
     }
 

--- a/src/settings/value_type.rs
+++ b/src/settings/value_type.rs
@@ -37,6 +37,7 @@ pub enum ValueType {
     Ipv6,
     Path,
     PortNumber,
+    Regex,
     YesNo,
     WebPassword,
     String(&'static [&'static str]),
@@ -180,6 +181,7 @@ impl ValueType {
                     false
                 }
             }
+            ValueType::Regex => Regex::new(value).is_ok(),
             ValueType::YesNo => match value {
                 "yes" | "no" => true,
                 _ => false
@@ -254,6 +256,7 @@ mod tests {
             ),
             (ValueType::Path, "/tmp/directory/file.ext", true),
             (ValueType::PortNumber, "9000", true),
+            (ValueType::Regex, "^.*example$", true),
             (ValueType::YesNo, "yes", true),
             (ValueType::String(&["boxed", ""]), "boxed", true),
         ];
@@ -309,6 +312,7 @@ mod tests {
             (ValueType::Ipv6, "192.168.0.3", false),
             (ValueType::Path, "~/tmp/directory/file.ext", false),
             (ValueType::PortNumber, "65536", false),
+            (ValueType::Regex, "example\\", false),
             (ValueType::YesNo, "true", false),
             (ValueType::String(&["boxed", ""]), "lan", false),
         ];

--- a/src/settings/value_type.rs
+++ b/src/settings/value_type.rs
@@ -228,47 +228,40 @@ mod tests {
             .unwrap_or_else(|| "lo".to_owned());
 
         let tests = vec![
-            (ValueType::Boolean, "false", true),
+            (ValueType::Boolean, "false"),
             (
                 ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4]),
-                "pi.hole,127.0.0.1",
-                true
+                "pi.hole,127.0.0.1"
             ),
             (
                 ValueType::ConditionalForwardingReverse,
-                "1.168.192.in-addr.arpa",
-                true
+                "1.168.192.in-addr.arpa"
             ),
-            (ValueType::Decimal, "3.14", true),
-            (ValueType::Domain, "domain.com", true),
-            (ValueType::Filename, "c3po", true),
-            (ValueType::Hostname, "localhost", true),
-            (ValueType::Integer, "8675309", true),
-            (ValueType::Interface, &available_interface, true),
-            (ValueType::Ipv4, "192.168.2.9", true),
-            (ValueType::IPv4OptionalPort, "192.168.4.5:80", true),
-            (ValueType::IPv4OptionalPort, "192.168.3.3", true),
-            (ValueType::Ipv4Mask, "192.168.0.3/24", true),
-            (
-                ValueType::Ipv6,
-                "f7c4:12f8:4f5a:8454:5241:cf80:d61c:3e2c",
-                true
-            ),
-            (ValueType::Path, "/tmp/directory/file.ext", true),
-            (ValueType::PortNumber, "9000", true),
-            (ValueType::Regex, "^.*example$", true),
-            (ValueType::YesNo, "yes", true),
-            (ValueType::String(&["boxed", ""]), "boxed", true),
+            (ValueType::Decimal, "3.14"),
+            (ValueType::Domain, "domain.com"),
+            (ValueType::Filename, "c3po"),
+            (ValueType::Hostname, "localhost"),
+            (ValueType::Integer, "8675309"),
+            (ValueType::Interface, &available_interface),
+            (ValueType::Ipv4, "192.168.2.9"),
+            (ValueType::IPv4OptionalPort, "192.168.4.5:80"),
+            (ValueType::IPv4OptionalPort, "192.168.3.3"),
+            (ValueType::Ipv4Mask, "192.168.0.3/24"),
+            (ValueType::Ipv6, "f7c4:12f8:4f5a:8454:5241:cf80:d61c:3e2c"),
+            (ValueType::Path, "/tmp/directory/file.ext"),
+            (ValueType::PortNumber, "9000"),
+            (ValueType::Regex, "^.*example$"),
+            (ValueType::YesNo, "yes"),
+            (ValueType::String(&["boxed", ""]), "boxed"),
         ];
 
-        for (setting, value, result) in tests {
+        for (setting, value) in tests {
+            let result = setting.is_valid(value);
+
             assert_eq!(
-                setting.is_valid(value),
-                result,
+                result, true,
                 "{:?}.is_valid({:?}) == {}",
-                setting,
-                value,
-                result
+                setting, value, result
             );
         }
     }
@@ -276,55 +269,48 @@ mod tests {
     #[test]
     fn test_value_type_invalid() {
         let tests = vec![
-            (ValueType::Boolean, "yes", false),
+            (ValueType::Boolean, "yes"),
             (
                 ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4]),
-                "123, $test,",
-                false
+                "123, $test,"
             ),
             (
                 ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4]),
-                "123,",
-                false
+                "123,"
             ),
-            (
-                ValueType::ConditionalForwardingReverse,
-                "www.pi-hole.net",
-                false
-            ),
-            (ValueType::Decimal, "3/4", false),
-            (ValueType::Decimal, "3.14.15.26", false),
-            (ValueType::Domain, "D0#A!N", false),
-            (ValueType::Filename, "c3p0/", false),
-            (ValueType::Hostname, ".localhost", false),
-            (ValueType::Hostname, "localhost.", false),
-            (ValueType::Hostname, "127.0.0.1", false),
-            (ValueType::Hostname, "my.ho$t.name", false),
-            (ValueType::Integer, "9.9", false),
-            (ValueType::Integer, "10m3", false),
-            (ValueType::Interface, "/dev/net/ev9d9", false),
-            (ValueType::Ipv4, "192.168.0.3/24", false),
-            (ValueType::Ipv4, "192.168.0.2:53", false),
-            (ValueType::IPv4OptionalPort, "192.168.4.5 port 1000", false),
-            (ValueType::IPv4OptionalPort, "192.168.6.8:arst", false),
-            (ValueType::Ipv4Mask, "192.168.2.9", false),
-            (ValueType::Ipv4Mask, "192.168.1.1/qwfp", false),
-            (ValueType::Ipv6, "192.168.0.3", false),
-            (ValueType::Path, "~/tmp/directory/file.ext", false),
-            (ValueType::PortNumber, "65536", false),
-            (ValueType::Regex, "example\\", false),
-            (ValueType::YesNo, "true", false),
-            (ValueType::String(&["boxed", ""]), "lan", false),
+            (ValueType::ConditionalForwardingReverse, "www.pi-hole.net"),
+            (ValueType::Decimal, "3/4"),
+            (ValueType::Decimal, "3.14.15.26"),
+            (ValueType::Domain, "D0#A!N"),
+            (ValueType::Filename, "c3p0/"),
+            (ValueType::Hostname, ".localhost"),
+            (ValueType::Hostname, "localhost."),
+            (ValueType::Hostname, "127.0.0.1"),
+            (ValueType::Hostname, "my.ho$t.name"),
+            (ValueType::Integer, "9.9"),
+            (ValueType::Integer, "10m3"),
+            (ValueType::Interface, "/dev/net/ev9d9"),
+            (ValueType::Ipv4, "192.168.0.3/24"),
+            (ValueType::Ipv4, "192.168.0.2:53"),
+            (ValueType::IPv4OptionalPort, "192.168.4.5 port 1000"),
+            (ValueType::IPv4OptionalPort, "192.168.6.8:arst"),
+            (ValueType::Ipv4Mask, "192.168.2.9"),
+            (ValueType::Ipv4Mask, "192.168.1.1/qwfp"),
+            (ValueType::Ipv6, "192.168.0.3"),
+            (ValueType::Path, "~/tmp/directory/file.ext"),
+            (ValueType::PortNumber, "65536"),
+            (ValueType::Regex, "example\\"),
+            (ValueType::YesNo, "true"),
+            (ValueType::String(&["boxed", ""]), "lan"),
         ];
 
-        for (setting, value, result) in tests {
+        for (setting, value) in tests {
+            let result = setting.is_valid(value);
+
             assert_eq!(
-                setting.is_valid(value),
-                result,
+                result, false,
                 "{:?}.is_valid({:?}) == {}",
-                setting,
-                value,
-                result
+                setting, value, result
             );
         }
     }


### PR DESCRIPTION
`List` was using different logic to determine if a string was a domain than the rest of the API, including the settings. Now it shares the validation logic.

The whitelist and blacklist now allow hostnames to be added. There wasn't much reason to prevent this, and it's a valid use case. The web interface's validation will need to be updated to support this.

The `ValueType` tests were simplified slightly (removed redundant code).