### PR TITLE
Return version information when given certain CLI arguments and upload API_HASH

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,13 +68,21 @@ version: 2
         name: "Upload"
         command: |
           [ -z "$FTL_SECRET" ] && exit 0
+
           sha1sum ${BIN_NAME} > ${BIN_NAME}.sha1
           cat ${BIN_NAME}.sha1
+
           curl https://ftl.pi-hole.net:8080/FTL-client -o FTL-client
           chmod +x ./FTL-client
           [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" "${BIN_NAME}" "${FTL_SECRET}"
           [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" "${BIN_NAME}.sha1" "${FTL_SECRET}"
           [[ "$CIRCLE_PR_NUMBER" == "" ]] && ./FTL-client "${CIRCLE_BRANCH}" pihole-api*.deb "${FTL_SECRET}"
+
+          if [[ "$CIRCLE_PR_NUMBER" == "" && "$CIRCLE_JOB" == "x86_64" ]]; then
+            echo "${CIRCLE_SHA1:0:7}" > API_HASH
+            ./FTL-client "${CIRCLE_BRANCH}" API_HASH "${FTL_SECRET}"
+          fi
+
           rm ./FTL-client
       # Save the files necessary for building the RPM
     - persist_to_workspace:

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use std::process::Command;
+use std::{env, process::Command};
 
 fn main() {
     // Read Git data and expose it to the API at compile time
@@ -19,12 +19,15 @@ fn main() {
         .unwrap_or_default();
     let tag = String::from_utf8(tag_raw).unwrap();
 
-    let branch_raw = Command::new("git")
-        .args(&["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
-        .map(|output| output.stdout)
-        .unwrap_or_default();
-    let branch = String::from_utf8(branch_raw).unwrap();
+    // Use the CIRCLE_BRANCH variable if it exists
+    let branch = env::var("CIRCLE_BRANCH").unwrap_or_else(|_| {
+        let branch_raw = Command::new("git")
+            .args(&["rev-parse", "--abbrev-ref", "HEAD"])
+            .output()
+            .map(|output| output.stdout)
+            .unwrap_or_default();
+        String::from_utf8(branch_raw).unwrap()
+    });
 
     let hash_raw = Command::new("git")
         .args(&["rev-parse", "HEAD"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,57 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
+use std::env;
+
 fn main() {
+    // Collect all arguments except for the first, which is the program name
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    // Handle the arguments if any
+    if !args.is_empty() {
+        handle_args(args);
+        return;
+    }
+
+    // Only run the API if there are no arguments
     if let Err(e) = pihole_api::start() {
         e.print_stacktrace();
     }
+}
+
+fn handle_args(args: Vec<String>) {
+    // There should only be one argument
+    if args.len() != 1 {
+        print_usage();
+        return;
+    }
+
+    match args[0].as_str() {
+        "version" => print_version(),
+        "branch" => println!("{}", env!("GIT_BRANCH")),
+        "hash" => println!("{}", get_hash()),
+        "help" | _ => print_usage()
+    }
+}
+
+fn print_version() {
+    let tag = env!("GIT_TAG");
+
+    if !tag.is_empty() {
+        println!("{}", tag);
+    } else {
+        println!("vDev-{}", get_hash());
+    }
+}
+
+fn print_usage() {
+    let program_name = env::args()
+        .next()
+        .unwrap_or_else(|| "pihole-API".to_owned());
+
+    println!("Usage: {} [version | branch | hash | help]", program_name);
+}
+
+fn get_hash() -> &'static str {
+    env!("GIT_HASH").get(0..7).unwrap_or_default()
 }


### PR DESCRIPTION
```
Usage: pihole-API [version | branch | hash | help]
```

This will be useful when checking for new versions in the updater.

The Git hash will be uploaded from the CI into an `API_HASH` file. This file can be used by the updater to check if it should update the API.

The branch and tag information should be more accurate than before (via the version endpoint). It will pull from CircleCI if possible, and it will also use the master branch if it's in a branch-less tag build.

The API will start up normally when given no arguments.