### PR TITLE
Allow the target profile (release/debug) to be configured when packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ version: 2
     - run:
         name: "Build DEB"
         command: |
-          export DEB_BUILD_OPTIONS=nostrip
+          export DEB_BUILD_OPTIONS=nostrip TARGET_PROFILE=release
           dpkg-buildpackage -b -a $DEB_ARCH
           mv ../pihole-api*.deb .
           [[ "$CIRCLE_JOB" != "arm" ]] || for file in pihole-api*.deb; do mv $file ${file//armhf/arm}; done
@@ -108,6 +108,7 @@ version: 2
     - run:
         name: "Build RPM"
         command: |
+          export TARGET_PROFILE=release
           mkdir -p ~/rpmbuild/{SOURCES,SPECS}
           mv rpm/pihole-api.spec ~/rpmbuild/SPECS
           mv * ~/rpmbuild/SOURCES

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ clean:
 
 install:
 	mkdir -p $(DESTDIR)/usr/bin
-	install -m 755 target/$(TARGET)/release/pihole_api $(DESTDIR)/usr/bin/pihole-API
+	install -m 755 target/$(TARGET)/$(TARGET_PROFILE)/pihole_api $(DESTDIR)/usr/bin/pihole-API


### PR DESCRIPTION
This makes it possible to build a debug package for development purposes. Debug builds can take advantage of incremental compilation, which means they only compile what's changed. This makes the development cycle faster.