### PR TITLE
Fix query privacy level not taken into consideration in history endpoint

### DIFF
--- a/src/databases/ftl/model.rs
+++ b/src/databases/ftl/model.rs
@@ -30,7 +30,7 @@ pub enum CounterTableEntry {
 #[cfg_attr(test, derive(PartialEq, Debug))]
 #[derive(Queryable)]
 pub struct FtlDbQuery {
-    pub id: Option<i32>,
+    pub id: i32,
     pub timestamp: i32,
     pub query_type: i32,
     pub status: i32,

--- a/src/databases/ftl/schema.rs
+++ b/src/databases/ftl/schema.rs
@@ -38,7 +38,7 @@ table! {
 
 table! {
     queries (id) {
-        id -> Nullable<Integer>,
+        id -> Integer,
         timestamp -> Integer,
         #[sql_name = "type"]
         query_type -> Integer,

--- a/src/routes/stats/common.rs
+++ b/src/routes/stats/common.rs
@@ -19,6 +19,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH}
 };
 
+/// The designated hidden domain
+pub const HIDDEN_DOMAIN: &str = "hidden";
+
+/// The designated hidden client IP address
+pub const HIDDEN_CLIENT: &str = "0.0.0.0";
+
 /// Remove clients from the `clients` vector if they show up in
 /// [`SetupVarsEntry::ApiExcludeClients`].
 ///
@@ -93,25 +99,13 @@ pub fn get_excluded_domains(env: &Env) -> Result<Vec<String>, Error> {
 /// Remove clients from the `clients` vector if they are marked as hidden due
 /// to the privacy level.
 pub fn remove_hidden_clients(clients: &mut Vec<&FtlClient>, strings: &FtlStrings) {
-    let hidden_client_ip = get_hidden_client_ip();
-    clients.retain(|client| client.get_ip(strings) != hidden_client_ip);
-}
-
-/// Get the hidden client IP address
-pub fn get_hidden_client_ip() -> &'static str {
-    "0.0.0.0"
+    clients.retain(|client| client.get_ip(strings) != HIDDEN_CLIENT);
 }
 
 /// Remove domains from the `domains` vector if they are marked as hidden due
 /// to the privacy level.
 pub fn remove_hidden_domains(domains: &mut Vec<&FtlDomain>, strings: &FtlStrings) {
-    let hidden_domain = get_hidden_domain();
-    domains.retain(|domain| domain.get_domain(strings) != hidden_domain);
-}
-
-/// Get the designated hidden domain
-pub fn get_hidden_domain() -> &'static str {
-    "hidden"
+    domains.retain(|domain| domain.get_domain(strings) != HIDDEN_DOMAIN);
 }
 
 /// Get the current overTime slot index, based on the current time. If all of

--- a/src/routes/stats/database/over_time_clients_db.rs
+++ b/src/routes/stats/database/over_time_clients_db.rs
@@ -15,7 +15,7 @@ use crate::{
     routes::{
         auth::User,
         stats::{
-            common::{get_excluded_clients, get_hidden_client_ip},
+            common::{get_excluded_clients, HIDDEN_CLIENT},
             database::over_time_history_db::align_from_until,
             over_time_clients::{OverTimeClientItem, OverTimeClients}
         }
@@ -127,7 +127,7 @@ fn get_client_identifiers(
 
     // Find clients which should not be used
     let mut ignored_clients = get_excluded_clients(env)?;
-    ignored_clients.push(get_hidden_client_ip().to_owned());
+    ignored_clients.push(HIDDEN_CLIENT.to_owned());
 
     let client_identifiers = queries
         .select(client)

--- a/src/routes/stats/database/top_clients_db.rs
+++ b/src/routes/stats/database/top_clients_db.rs
@@ -16,7 +16,7 @@ use crate::{
         auth::User,
         stats::{
             check_privacy_level_top_clients,
-            common::{get_excluded_clients, get_hidden_client_ip},
+            common::{get_excluded_clients, HIDDEN_CLIENT},
             database::{get_blocked_query_count, get_query_type_counts},
             top_clients::{TopClientItemReply, TopClientParams, TopClientsReply}
         }
@@ -123,7 +123,7 @@ fn get_ignored_clients(env: &Env) -> Result<Vec<String>, Error> {
     let mut ignored_clients = get_excluded_clients(env)?;
 
     // Ignore the hidden client IP (due to privacy level)
-    ignored_clients.push(get_hidden_client_ip().to_owned());
+    ignored_clients.push(HIDDEN_CLIENT.to_owned());
 
     Ok(ignored_clients)
 }

--- a/src/routes/stats/database/top_domains_db.rs
+++ b/src/routes/stats/database/top_domains_db.rs
@@ -16,7 +16,7 @@ use crate::{
         auth::User,
         stats::{
             check_privacy_level_top_domains, check_query_log_show_top_domains,
-            common::{get_excluded_domains, get_hidden_domain},
+            common::{get_excluded_domains, HIDDEN_DOMAIN},
             database::{
                 query_types_db::get_query_type_counts, summary_db::get_blocked_query_count
             },
@@ -119,7 +119,7 @@ fn get_ignored_domains(env: &Env, audit: bool) -> Result<Vec<String>, Error> {
     let mut ignored_domains = get_excluded_domains(env)?;
 
     // Ignore the hidden domain (due to privacy level)
-    ignored_domains.push(get_hidden_domain().to_owned());
+    ignored_domains.push(HIDDEN_DOMAIN.to_owned());
 
     // If audit flag is true, only include unaudited domains
     if audit {

--- a/src/routes/stats/history/database.rs
+++ b/src/routes/stats/history/database.rs
@@ -73,7 +73,7 @@ pub fn load_queries_from_database(
     let cursor = if results.len() == limit + 1 {
         Some(HistoryCursor {
             id: None,
-            db_id: Some(results[limit].id.unwrap() as i64)
+            db_id: Some(results[limit].id as i64)
         })
     } else {
         None

--- a/src/routes/stats/history/skip_to_cursor.rs
+++ b/src/routes/stats/history/skip_to_cursor.rs
@@ -108,7 +108,7 @@ mod test {
         use crate::databases::ftl::queries::dsl::*;
 
         let expected_queries = vec![FtlDbQuery {
-            id: Some(1),
+            id: 1,
             timestamp: 0,
             query_type: 6,
             status: 3,


### PR DESCRIPTION
Each query stores the privacy level it was created under so that changing the privacy level would still keep the contents hidden. This privacy level was not taken into account when returning queries from the history endpoint.

Other misc changes:
- Fix the DB query's ID field to not be nullable
- Use constants for the hidden domain and client strings instead of functions