### PR TITLE
Fix mounting the web interface to the root, `/`

### DIFF
--- a/src/env/config/web.rs
+++ b/src/env/config/web.rs
@@ -8,7 +8,7 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
-use std::path::PathBuf;
+use std::{ffi::OsStr, path::PathBuf};
 
 /// Configuration settings for hosting the web interface
 #[derive(Deserialize, Clone)]
@@ -43,7 +43,11 @@ impl WebConfig {
 
     /// Get the web mount path with a trailing slash
     pub fn path_with_trailing_slash(&self) -> String {
-        self.path.to_string_lossy().into_owned() + "/"
+        if self.path == OsStr::new("/") {
+            "/".to_owned()
+        } else {
+            self.path.to_string_lossy().into_owned() + "/"
+        }
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -115,15 +115,16 @@ fn setup(
 
     // Conditionally enable and mount the web interface
     let server = if env.config().web.enabled {
+        let web_route = env.config().web.path.to_string_lossy();
+
         // Check if the root redirect should be enabled
-        let server = if env.config().web.root_redirect {
+        let server = if env.config().web.root_redirect && web_route != "/" {
             server.mount("/", routes![web::web_interface_redirect])
         } else {
             server
         };
 
         // Mount the web interface at the configured route
-        let web_route = env.config().web.path.to_string_lossy();
         server.mount(
             &web_route,
             routes![web::web_interface_index, web::web_interface]


### PR DESCRIPTION
This is a special case, and the API needed some tweaks to support it.