### PR TITLE
Add DHCP rapid commit to DHCP settings endpoint

### DIFF
--- a/src/routes/settings/dhcp.rs
+++ b/src/routes/settings/dhcp.rs
@@ -205,7 +205,7 @@ mod test {
                 "lease_time": 24,
                 "domain": "lan",
                 "ipv6_support": false,
-                "rapid_commit": false
+                "rapid_commit": true
             }))
             .test();
     }

--- a/src/settings/dnsmasq.rs
+++ b/src/settings/dnsmasq.rs
@@ -420,6 +420,7 @@ mod tests {
              dhcp-name-match=set:wpad-ignore,wpad\n\
              dhcp-ignore-names=tag:wpad-ignore\n\
              domain=lan\n\
+             dhcp-rapid-commit\n\
              dhcp-option=option6:dns-server,[::]\n\
              dhcp-range=::100,::1ff,constructor:eth0,ra-names,slaac,24h\n\
              ra-param=*,0,0\n",
@@ -447,6 +448,7 @@ mod tests {
              dhcp-name-match=set:wpad-ignore,wpad\n\
              dhcp-ignore-names=tag:wpad-ignore\n\
              domain=lan\n\
+             dhcp-rapid-commit\n\
              dhcp-option=option6:dns-server,[::]\n\
              dhcp-range=::100,::1ff,constructor:eth0,ra-names,slaac,infinite\n\
              ra-param=*,0,0\n",

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -289,7 +289,7 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::DhcpIpv6 => "false",
             SetupVarsEntry::DhcpLeasetime => "24",
             SetupVarsEntry::DhcpStart => "",
-            SetupVarsEntry::DhcpRapidCommit => "false",
+            SetupVarsEntry::DhcpRapidCommit => "true",
             SetupVarsEntry::DhcpRouter => "",
             SetupVarsEntry::DnsmasqListening => "local",
             SetupVarsEntry::Dnssec => "false",


### PR DESCRIPTION
DHCP rapid commit was previously supported in the Dnsmasq config generation code, but it was not exposed through the DHCP settings endpoint.