### PR TITLE
Version the docker build containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 .job_template: &job_template
   docker:
-    - image: pihole/api-build:$CIRCLE_JOB
+    - image: pihole/api-build:v1-$CIRCLE_JOB
   steps:
     - checkout
     - restore_cache:

--- a/docker/aarch64/Dockerfile
+++ b/docker/aarch64/Dockerfile
@@ -20,3 +20,5 @@ ENV PATH="/root/.cargo/bin:$PATH" \
     TARGET_CC=aarch64-linux-gnu-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
     CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+
+LABEL version=1

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -19,3 +19,5 @@ ENV PATH="/root/.cargo/bin:$PATH" \
     TARGET_CC=arm-linux-gnueabi-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-linux-gnueabi-gcc \
     CC_arm_unknown_linux_gnueabi=arm-linux-gnueabi-gcc
+
+LABEL version=1

--- a/docker/armhf/Dockerfile
+++ b/docker/armhf/Dockerfile
@@ -19,3 +19,5 @@ ENV PATH="/root/.cargo/bin:$PATH" \
     TARGET_CC=arm-linux-gnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
     CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc
+
+LABEL version=1

--- a/docker/x86_32/Dockerfile
+++ b/docker/x86_32/Dockerfile
@@ -16,3 +16,5 @@ RUN curl -L -o ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.12.
     mv ghr_*_linux_amd64/ghr /usr/bin/ghr
 
 ENV PATH="/root/.cargo/bin:$PATH"
+
+LABEL version=1

--- a/docker/x86_64-musl/Dockerfile
+++ b/docker/x86_64-musl/Dockerfile
@@ -21,3 +21,5 @@ RUN curl -L -o ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.12.
 ENV TARGET_CC=musl-gcc \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=musl-gcc \
     CC_x86_64_unknown_linux_musl=musl-gcc
+
+LABEL version=1

--- a/docker/x86_64/Dockerfile
+++ b/docker/x86_64/Dockerfile
@@ -16,3 +16,5 @@ RUN rustup component add rustfmt clippy
 RUN curl -L -o ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \
     tar -xzf ghr.tar.gz && \
     mv ghr_*_linux_amd64/ghr /usr/bin/ghr
+
+LABEL version=1


### PR DESCRIPTION
The version is prepended to the tag, ex. `pi-hole/api-build:v1-arm`.
It is also added as a label to the docker image.

This will prevent issues where the docker container is updated in an incompatible way (new Rust version) via a PR but other builds run before it is merged. This causes the other builds to fail because they are using a newer rust version than what is in `rust-toolchain`.