### PR TITLE
Support IPv6 addresses (with ports) as upstream servers

### DIFF
--- a/src/routes/stats/database/over_time_clients_db.rs
+++ b/src/routes/stats/database/over_time_clients_db.rs
@@ -94,8 +94,8 @@ fn over_time_clients_db_impl(
     let clients = client_identifiers
         .into_iter()
         .map(|client_identifier| {
-            if ValueType::Ipv4.is_valid(&client_identifier)
-                || ValueType::Ipv6.is_valid(&client_identifier)
+            if ValueType::IPv4.is_valid(&client_identifier)
+                || ValueType::IPv6.is_valid(&client_identifier)
             {
                 // If the identifier is an IP address, use it as the client IP
                 ClientReply {

--- a/src/routes/stats/database/top_clients_db.rs
+++ b/src/routes/stats/database/top_clients_db.rs
@@ -81,8 +81,8 @@ fn top_clients_db_impl(
         execute_top_clients_query(db, from, until, ignored_clients, blocked, ascending, limit)?
             .into_iter()
             .map(|(client_identifier, count)| {
-                if ValueType::Ipv4.is_valid(&client_identifier)
-                    || ValueType::Ipv6.is_valid(&client_identifier)
+                if ValueType::IPv4.is_valid(&client_identifier)
+                    || ValueType::IPv6.is_valid(&client_identifier)
                 {
                     // If the identifier is an IP address, use it as the client IP
                     TopClientItemReply {

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -262,7 +262,9 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::HostRecord => ValueType::Domain,
             SetupVarsEntry::Ipv4Address => ValueType::IPv4Mask,
             SetupVarsEntry::Ipv6Address => ValueType::IPv6,
-            SetupVarsEntry::PiholeDns(_) => ValueType::IPv4OptionalPort,
+            SetupVarsEntry::PiholeDns(_) => {
+                ValueType::Any(&[ValueType::IPv4OptionalPort, ValueType::IPv6OptionalPort])
+            }
             SetupVarsEntry::PiholeDomain => ValueType::Hostname,
             SetupVarsEntry::PiholeInterface => ValueType::Interface,
             SetupVarsEntry::QueryLogging => ValueType::Boolean,

--- a/src/settings/entries.rs
+++ b/src/settings/entries.rs
@@ -237,7 +237,7 @@ impl ConfigEntry for SetupVarsEntry {
     fn value_type(&self) -> ValueType {
         match self {
             SetupVarsEntry::ApiExcludeClients => {
-                ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4, ValueType::Ipv6])
+                ValueType::Array(&[ValueType::Hostname, ValueType::IPv4, ValueType::IPv6])
             }
             SetupVarsEntry::ApiExcludeDomains => ValueType::Array(&[ValueType::Hostname]),
             SetupVarsEntry::ApiQueryLogShow => {
@@ -248,20 +248,20 @@ impl ConfigEntry for SetupVarsEntry {
             SetupVarsEntry::DnsFqdnRequired => ValueType::Boolean,
             SetupVarsEntry::ConditionalForwarding => ValueType::Boolean,
             SetupVarsEntry::ConditionalForwardingDomain => ValueType::Hostname,
-            SetupVarsEntry::ConditionalForwardingIp => ValueType::Ipv4,
+            SetupVarsEntry::ConditionalForwardingIp => ValueType::IPv4,
             SetupVarsEntry::ConditionalForwardingReverse => ValueType::ConditionalForwardingReverse,
             SetupVarsEntry::DhcpActive => ValueType::Boolean,
-            SetupVarsEntry::DhcpEnd => ValueType::Ipv4,
+            SetupVarsEntry::DhcpEnd => ValueType::IPv4,
             SetupVarsEntry::DhcpIpv6 => ValueType::Boolean,
             SetupVarsEntry::DhcpLeasetime => ValueType::Integer,
-            SetupVarsEntry::DhcpStart => ValueType::Ipv4,
+            SetupVarsEntry::DhcpStart => ValueType::IPv4,
             SetupVarsEntry::DhcpRapidCommit => ValueType::Boolean,
-            SetupVarsEntry::DhcpRouter => ValueType::Ipv4,
+            SetupVarsEntry::DhcpRouter => ValueType::IPv4,
             SetupVarsEntry::DnsmasqListening => ValueType::String(&["all", "local", "single"]),
             SetupVarsEntry::Dnssec => ValueType::Boolean,
             SetupVarsEntry::HostRecord => ValueType::Domain,
-            SetupVarsEntry::Ipv4Address => ValueType::Ipv4Mask,
-            SetupVarsEntry::Ipv6Address => ValueType::Ipv6,
+            SetupVarsEntry::Ipv4Address => ValueType::IPv4Mask,
+            SetupVarsEntry::Ipv6Address => ValueType::IPv6,
             SetupVarsEntry::PiholeDns(_) => ValueType::IPv4OptionalPort,
             SetupVarsEntry::PiholeDomain => ValueType::Hostname,
             SetupVarsEntry::PiholeInterface => ValueType::Interface,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -17,5 +17,5 @@ pub use self::{
     dnsmasq::generate_dnsmasq_config,
     entries::{ConfigEntry, FtlConfEntry, SetupVarsEntry},
     privacy_level::FtlPrivacyLevel,
-    value_type::ValueType
+    value_type::*
 };

--- a/src/settings/value_type.rs
+++ b/src/settings/value_type.rs
@@ -33,11 +33,11 @@ pub enum ValueType {
     Hostname,
     Integer,
     Interface,
-    Ipv4,
+    IPv4,
     IPv4OptionalPort,
-    Ipv4Mask,
-    Ipv6,
-    Ipv6OptionalPort,
+    IPv4Mask,
+    IPv6,
+    IPv6OptionalPort,
     Path,
     PortNumber,
     Regex,
@@ -130,7 +130,7 @@ impl ValueType {
                     .iter()
                     .any(|interface| interface.name == value)
             }
-            ValueType::Ipv4 => {
+            ValueType::IPv4 => {
                 // Valid and in allowable range
                 // (4 octets)
                 // Test if valid address falls within permitted ranges
@@ -155,7 +155,7 @@ impl ValueType {
                     false
                 }
             }
-            ValueType::Ipv4Mask => {
+            ValueType::IPv4Mask => {
                 // Valid, in allowable range, and with mask
                 // (4 octets, with mask)
                 if !value.contains('/') {
@@ -165,8 +165,8 @@ impl ValueType {
                 let (ip, mask) = value.split_at(value.rfind('/').unwrap());
                 ValueType::Integer.is_valid(&mask.replace("/", "")) && is_ipv4_valid(ip)
             }
-            ValueType::Ipv6 => is_ipv6_valid(value),
-            ValueType::Ipv6OptionalPort => get_ipv6_address_and_port(value).is_some(),
+            ValueType::IPv6 => is_ipv6_valid(value),
+            ValueType::IPv6OptionalPort => get_ipv6_address_and_port(value).is_some(),
             ValueType::Path => {
                 // Test if a path and filename have been specified
                 let path = Path::new(value);
@@ -276,7 +276,7 @@ mod tests {
                 "true"
             ),
             (
-                ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4]),
+                ValueType::Array(&[ValueType::Hostname, ValueType::IPv4]),
                 "pi.hole,127.0.0.1"
             ),
             (ValueType::Boolean, "false"),
@@ -290,16 +290,16 @@ mod tests {
             (ValueType::Hostname, "localhost"),
             (ValueType::Integer, "8675309"),
             (ValueType::Interface, &available_interface),
-            (ValueType::Ipv4, "192.168.2.9"),
+            (ValueType::IPv4, "192.168.2.9"),
             (ValueType::IPv4OptionalPort, "192.168.4.5:80"),
             (ValueType::IPv4OptionalPort, "192.168.3.3"),
-            (ValueType::Ipv4Mask, "192.168.0.3/24"),
-            (ValueType::Ipv6, "f7c4:12f8:4f5a:8454:5241:cf80:d61c:3e2c"),
+            (ValueType::IPv4Mask, "192.168.0.3/24"),
+            (ValueType::IPv6, "f7c4:12f8:4f5a:8454:5241:cf80:d61c:3e2c"),
             (
-                ValueType::Ipv6OptionalPort,
+                ValueType::IPv6OptionalPort,
                 "f7c4:12f8:4f5a:8454:5241:cf80:d61c:3e2c"
             ),
-            (ValueType::Ipv6OptionalPort, "[1fff:0:a88:85a3::ac1f]:8001"),
+            (ValueType::IPv6OptionalPort, "[1fff:0:a88:85a3::ac1f]:8001"),
             (ValueType::Path, "/tmp/directory/file.ext"),
             (ValueType::PortNumber, "9000"),
             (ValueType::Regex, "^.*example$"),
@@ -330,11 +330,11 @@ mod tests {
                 "192.168.1.1"
             ),
             (
-                ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4]),
+                ValueType::Array(&[ValueType::Hostname, ValueType::IPv4]),
                 "123, $test,"
             ),
             (
-                ValueType::Array(&[ValueType::Hostname, ValueType::Ipv4]),
+                ValueType::Array(&[ValueType::Hostname, ValueType::IPv4]),
                 "123,"
             ),
             (ValueType::Boolean, "yes"),
@@ -350,15 +350,15 @@ mod tests {
             (ValueType::Integer, "9.9"),
             (ValueType::Integer, "10m3"),
             (ValueType::Interface, "/dev/net/ev9d9"),
-            (ValueType::Ipv4, "192.168.0.3/24"),
-            (ValueType::Ipv4, "192.168.0.2:53"),
+            (ValueType::IPv4, "192.168.0.3/24"),
+            (ValueType::IPv4, "192.168.0.2:53"),
             (ValueType::IPv4OptionalPort, "192.168.4.5 port 1000"),
             (ValueType::IPv4OptionalPort, "192.168.6.8:arst"),
-            (ValueType::Ipv4Mask, "192.168.2.9"),
-            (ValueType::Ipv4Mask, "192.168.1.1/qwfp"),
-            (ValueType::Ipv6, "192.168.0.3"),
-            (ValueType::Ipv6OptionalPort, "192.168.0.3"),
-            (ValueType::Ipv6OptionalPort, "1fff:0:a88:85a3::ac1f#8001"),
+            (ValueType::IPv4Mask, "192.168.2.9"),
+            (ValueType::IPv4Mask, "192.168.1.1/qwfp"),
+            (ValueType::IPv6, "192.168.0.3"),
+            (ValueType::IPv6OptionalPort, "192.168.0.3"),
+            (ValueType::IPv6OptionalPort, "1fff:0:a88:85a3::ac1f#8001"),
             (ValueType::Path, "~/tmp/directory/file.ext"),
             (ValueType::PortNumber, "65536"),
             (ValueType::Regex, "example\\"),


### PR DESCRIPTION
This is the backend change necessary for supporting IPv6 upstreams in the web interface.

Notable changes:
- Add `ValueType::IPv6OptionalPort` and `ValueType::Any`
- Standardize the naming of IP value types
- Support generating the dnsmasq config with IPv6 upstreams

See pi-hole/web#203