### PR TITLE
Pass through the underlying error if the FTL socket connection fails

### DIFF
--- a/src/ftl/socket.rs
+++ b/src/ftl/socket.rs
@@ -49,15 +49,11 @@ impl FtlConnectionType {
         match *self {
             FtlConnectionType::Socket => {
                 // Try to connect to FTL
-                let mut stream = match UnixStream::connect(SOCKET_LOCATION) {
-                    Ok(s) => s,
-                    Err(_) => return Err(Error::from(ErrorKind::FtlConnectionFail))
-                };
+                let mut stream =
+                    UnixStream::connect(SOCKET_LOCATION).context(ErrorKind::FtlConnectionFail)?;
 
                 // Send the command
-                stream
-                    .write_all(format!(">{}\n", command).as_bytes())
-                    .context(ErrorKind::FtlConnectionFail)?;
+                writeln!(stream, ">{}", command).context(ErrorKind::FtlConnectionFail)?;
 
                 // Return the connection so the API can read the response
                 Ok(FtlConnection(Box::new(BufReader::new(stream))))


### PR DESCRIPTION
If the socket connection failed, the IO error (such as file not found) would not be shown. This change passes through the error so it can be logged.

This change also simplifies sending the command through the socket by using the `writeln!` macro.