### PR TITLE
Remove sqlite dependency from DEB

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Build-Depends: debhelper (>= 10), dh-systemd (>= 1.5)
 
 Package: pihole-api
 Architecture: any
-Depends: libsqlite3-0, libcap2-bin, ${shlibs:Depends}, ${misc:Depends}
+Depends: libcap2-bin, ${shlibs:Depends}, ${misc:Depends}
 Description: The Pi-hole API, including the Web Interface
  The Pi-hole API provides a RESTful service for the web interface. The web
  interface is embedded into the API and exposed under /admin.


### PR DESCRIPTION
As of #131 we statically link sqlite, so we do not need to depend on it in the package. Even if we didn't statically link it, it would have shown up in the `shlibs:Depends` variable.

~~This dependency is causing the package to fail to install on 64 bit Debian-based systems.~~
Above issue is unrelated, caused by using an incorrect/old DEB.