### PR TITLE
Turn on foreign keys for all DB connections automatically

### DIFF
--- a/src/databases/foreign_key_connection.rs
+++ b/src/databases/foreign_key_connection.rs
@@ -3,7 +3,7 @@
 // Network-wide ad blocking via your own hardware.
 //
 // API
-// Foreign key enabled SQLite connection
+// Foreign Key Enabled SQLite Connection
 //
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.

--- a/src/databases/foreign_key_connection.rs
+++ b/src/databases/foreign_key_connection.rs
@@ -1,0 +1,76 @@
+// Pi-hole: A black hole for Internet advertisements
+// (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+// Network-wide ad blocking via your own hardware.
+//
+// API
+// Foreign key enabled SQLite connection
+//
+// This file is copyright under the latest version of the EUPL.
+// Please see LICENSE file for your rights under this license.
+
+use diesel::{r2d2, Connection};
+use rocket_contrib::databases::{DatabaseConfig, Poolable};
+use std::ops::{Deref, DerefMut};
+
+/// A wrapper around `SqliteConnection` for use by `SqliteFKConnectionManager`
+pub struct SqliteFKConnection(diesel::SqliteConnection);
+
+impl Deref for SqliteFKConnection {
+    type Target = diesel::SqliteConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for SqliteFKConnection {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// This implementation is mostly copied from the implementation for
+// `SqliteConnection`, but uses `SqliteFKConnectionManager`
+impl Poolable for SqliteFKConnection {
+    type Manager = SqliteFKConnectionManager;
+    type Error = rocket_contrib::databases::r2d2::Error;
+
+    fn pool(config: DatabaseConfig) -> Result<r2d2::Pool<Self::Manager>, Self::Error> {
+        let manager = SqliteFKConnectionManager::new(config.url);
+        r2d2::Pool::builder()
+            .max_size(config.pool_size)
+            .build(manager)
+    }
+}
+
+/// A SQLite connection manager which automatically turns on foreign key support
+pub struct SqliteFKConnectionManager(pub diesel::r2d2::ConnectionManager<diesel::SqliteConnection>);
+
+impl SqliteFKConnectionManager {
+    pub fn new(database_url: &str) -> Self {
+        SqliteFKConnectionManager(diesel::r2d2::ConnectionManager::new(database_url))
+    }
+}
+
+impl r2d2::ManageConnection for SqliteFKConnectionManager {
+    type Connection = SqliteFKConnection;
+    type Error = r2d2::Error;
+
+    fn connect(&self) -> Result<Self::Connection, Self::Error> {
+        let conn = self.0.connect()?;
+
+        // Turn on foreign key support
+        conn.execute("PRAGMA FOREIGN_KEYS=ON")
+            .map_err(diesel::r2d2::Error::QueryError)?;
+
+        Ok(SqliteFKConnection(conn))
+    }
+
+    fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
+        self.0.is_valid(conn)
+    }
+
+    fn has_broken(&self, conn: &mut Self::Connection) -> bool {
+        self.0.has_broken(conn)
+    }
+}

--- a/src/databases/ftl/mod.rs
+++ b/src/databases/ftl/mod.rs
@@ -9,12 +9,9 @@
 // Please see LICENSE file for your rights under this license.
 
 #[cfg(test)]
-use crate::databases::start_test_transaction;
+use crate::databases::{foreign_key_connection::SqliteFKConnectionManager, start_test_transaction};
 #[cfg(test)]
-use diesel::{
-    r2d2::{ConnectionManager, Pool},
-    SqliteConnection
-};
+use diesel::{r2d2::Pool, SqliteConnection};
 
 mod model;
 mod schema;
@@ -27,8 +24,8 @@ pub const TEST_FTL_DATABASE_PATH: &str = "test/FTL.db";
 #[cfg(test)]
 lazy_static! {
     /// A connection pool for tests which need a database connection
-    static ref CONNECTION_POOL: Pool<ConnectionManager<SqliteConnection>> = {
-        let manager = diesel::r2d2::ConnectionManager::new(TEST_FTL_DATABASE_PATH);
+    static ref CONNECTION_POOL: Pool<SqliteFKConnectionManager> = {
+        let manager = SqliteFKConnectionManager::new(TEST_FTL_DATABASE_PATH);
         diesel::r2d2::Pool::builder().build(manager).unwrap()
     };
 }

--- a/src/databases/ftl/model.rs
+++ b/src/databases/ftl/model.rs
@@ -9,12 +9,13 @@
 // Please see LICENSE file for your rights under this license.
 
 use crate::{
+    databases::foreign_key_connection::SqliteFKConnection,
     ftl::{FtlDnssecType, FtlQueryReplyType},
     routes::stats::QueryReply
 };
 
 #[database("ftl_database")]
-pub struct FtlDatabase(diesel::SqliteConnection);
+pub struct FtlDatabase(SqliteFKConnection);
 
 #[allow(dead_code)]
 pub enum FtlTableEntry {

--- a/src/databases/gravity/mod.rs
+++ b/src/databases/gravity/mod.rs
@@ -9,12 +9,9 @@
 // Please see LICENSE file for your rights under this license.
 
 #[cfg(test)]
-use crate::databases::start_test_transaction;
+use crate::databases::{foreign_key_connection::SqliteFKConnectionManager, start_test_transaction};
 #[cfg(test)]
-use diesel::{
-    r2d2::{ConnectionManager, Pool},
-    SqliteConnection
-};
+use diesel::{r2d2::Pool, SqliteConnection};
 
 mod model;
 mod schema;
@@ -27,8 +24,8 @@ pub const TEST_GRAVITY_DATABASE_PATH: &str = "test/gravity.db";
 #[cfg(test)]
 lazy_static! {
     /// A connection pool for tests which need a database connection
-    static ref CONNECTION_POOL: Pool<ConnectionManager<SqliteConnection>> = {
-        let manager = diesel::r2d2::ConnectionManager::new(TEST_GRAVITY_DATABASE_PATH);
+    static ref CONNECTION_POOL: Pool<SqliteFKConnectionManager> = {
+        let manager = SqliteFKConnectionManager::new(TEST_GRAVITY_DATABASE_PATH);
         diesel::r2d2::Pool::builder().max_size(1).build(manager).unwrap()
     };
 }

--- a/src/databases/gravity/model.rs
+++ b/src/databases/gravity/model.rs
@@ -8,5 +8,7 @@
 // This file is copyright under the latest version of the EUPL.
 // Please see LICENSE file for your rights under this license.
 
+use crate::databases::foreign_key_connection::SqliteFKConnection;
+
 #[database("gravity_database")]
-pub struct GravityDatabase(diesel::SqliteConnection);
+pub struct GravityDatabase(SqliteFKConnection);

--- a/src/databases/mod.rs
+++ b/src/databases/mod.rs
@@ -26,6 +26,7 @@ use diesel::{
     SqliteConnection
 };
 
+mod foreign_key_connection;
 pub mod ftl;
 pub mod gravity;
 


### PR DESCRIPTION
The connection manager is wrapped in a new type ([newtype pattern]) to call `PRAGMA FOREIGN_KEYS=ON` for all new connections. To use the new connection manager, the SQLite connection struct is also wrapped.

[newtype pattern]: https://github.com/rust-unofficial/patterns/blob/master/patterns/newtype.md