### PR TITLE
Add code coverage to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ version: 2
             exit 0
           fi
 
-          grcov target -t lcov --branch --ignore-not-existing --ignore-dir "/*" -o lcov.info
+          grcov target -t lcov --branch --ignore-not-existing --ignore-dir "/*" --ignore-dir "*build.rs" -o lcov.info
           bash <(curl -s https://codecov.io/bash) -f lcov.info
     - run:
         name: "Build DEB"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ version: 2
           export CARGO_INCREMENTAL=0
           export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Zno-landing-pads"
 
-          time cargo test --target $TARGET
+          time cargo test
     - run:
         name: "Upload Code Coverage"
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,20 @@ version: 2
     - run:
         name: "Test"
         command: |
-          [[ "$CIRCLE_JOB" != "x86_64-musl" ]] || time cargo test --release --target $TARGET
+          if [[ "$CIRCLE_JOB" != "x86_64-musl" ]]; then
+            exit 0
+          fi
+
+          # These flags are used so the test results can be used for code coverage
+          export CARGO_INCREMENTAL=0
+          export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Zno-landing-pads"
+
+          time cargo test --target $TARGET
+    - run:
+        name: "Upload Code Coverage"
+        command: |
+          grcov target -t lcov --branch --ignore-not-existing --ignore-dir "/*" -o lcov.info
+          bash <(curl -s https://codecov.io/bash) -f lcov.info
     - run:
         name: "Build DEB"
         command: |
@@ -61,7 +74,7 @@ version: 2
           mv ../pihole-api*.deb .
           [[ "$CIRCLE_JOB" != "arm" ]] || for file in pihole-api*.deb; do mv $file ${file//armhf/arm}; done
     - run:
-        name: "Upload"
+        name: "Upload Artifacts"
         command: |
           [[ -z "$FTL_SECRET" || "$CIRCLE_PR_NUMBER" != "" ]] && exit 0
           DIR="${CIRCLE_TAG:-${CIRCLE_BRANCH}}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ version: 2
           - debian/pihole-API.service
           - rpm/pihole-api.spec
     - save_cache:
-        key: v3-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
+        key: v4-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
         paths:
           - target
           - /root/.cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ version: 2
     - run:
         name: "Upload Code Coverage"
         command: |
+          if [[ "$CIRCLE_JOB" != "x86_64-musl" ]]; then
+            exit 0
+          fi
+
           grcov target -t lcov --branch --ignore-not-existing --ignore-dir "/*" -o lcov.info
           bash <(curl -s https://codecov.io/bash) -f lcov.info
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2
         keys:
           # Find a cache corresponding to this specific target and Cargo.lock checksum.
           # There are two dashes used between job and checksum to avoid x86_64 using the x86_64-musl cache
-          - v3-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
+          - v4-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
     - run:
         name: "Download Web"
         command: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ CMakeLists.txt
 .idea
 !.idea/codeStyles/*
 !.idea/codeStyleSettings.xml
+
+### Testing
+# Code coverage info file
+lcov.info
+
+# Code coverage HTML report
+/report/

--- a/docker/x86_64-musl/Dockerfile
+++ b/docker/x86_64-musl/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
 
 ENV PATH="/root/.cargo/bin:$PATH"
 
-RUN rustup component add rustfmt clippy
+RUN rustup component add rustfmt clippy && \
+    cargo install grcov
 
 # Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
 RUN curl -L -o ghr.tar.gz https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \

--- a/src/service.rs
+++ b/src/service.rs
@@ -15,7 +15,7 @@
 //! implement. The code which uses the service references it as a trait object.
 //!
 //! Example:
-//! ```
+//! ```rust,ignore
 //! trait MyService {
 //!     fn something(&self);
 //! }
@@ -51,7 +51,7 @@ use rocket::State;
 /// the request guard which will be created.
 ///
 /// Example:
-/// ```
+/// ```rust,ignore
 /// service!(MyServiceGuard, MyService, MyServiceImpl, MyServiceMock);
 ///
 /// // Now you can use the guard


### PR DESCRIPTION
Code coverage is generated by using the `profile` compiler option (must be run on x86_64-gnu, not musl), along with some other options. The data is consolidated by [`grcov`] and shipped off to Codecov.

This follows the same code coverage workflow as the IntelliJ Rust plugin uses, introduced in the most recent release:
https://intellij-rust.github.io/2019/07/22/changelog-102.html

[`grcov`]: https://github.com/mozilla/grcov

Closes #140 