### PR TITLE
Run Clippy in debug mode during lint CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ version: 2
     - run:
         name: "Code Lint Check"
         command: |
-          [[ "$CIRCLE_JOB" != "x86_64-musl" ]] || cargo clippy --release --all-targets --all-features -- -D clippy::all
+          [[ "$CIRCLE_JOB" != "x86_64-musl" ]] || cargo clippy --all-targets --all-features -- -D clippy::all
     - run:
         name: "Build"
         command: |


### PR DESCRIPTION
This should speed up this step a little bit.