### PR TITLE
Fix code coverage error by refreshing CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ version: 2
         keys:
           # Find a cache corresponding to this specific target and Cargo.lock checksum.
           # There are two dashes used between job and checksum to avoid x86_64 using the x86_64-musl cache
-          - v4-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
+          - v5-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
     - run:
         name: "Download Web"
         command: |
@@ -106,7 +106,7 @@ version: 2
           - debian/pihole-API.service
           - rpm/pihole-api.spec
     - save_cache:
-        key: v4-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
+        key: v5-cargo-{{ .Environment.CIRCLE_JOB }}--{{ checksum "Cargo.lock" }}
         paths:
           - target
           - /root/.cargo


### PR DESCRIPTION
The code coverage profiling is failing on some PRs, likely due to a bad cache of coverage data introduced sometime during the code coverage introduction (while experimenting with options).

This will bump the cache version to start with a fresh cache. If this turns out to not fix it, we'll investigate it more.